### PR TITLE
Bypass credential selection for single credential type in offers

### DIFF
--- a/src/pages/ScanPage.tsx
+++ b/src/pages/ScanPage.tsx
@@ -37,7 +37,9 @@ export function ScanPage() {
     if (offerState.status === 'success' && offerState.session) {
       const { credential_types } = offerState.session
       if (credential_types.length === 1) {
-        navigate(credentialTypeDetailsPath(credential_types[0].credential_configuration_id))
+        navigate(
+          credentialTypeDetailsPath(credential_types[0].credential_configuration_id)
+        )
       } else {
         navigate(routes.credentialTypes)
       }
@@ -235,7 +237,11 @@ export function ScanPage() {
         {showErrorCard && (
           <IssuanceErrorCard
             error={offerState.status === 'error' ? offerState.apiError : null}
-            rawMessage={offerState.status === 'error' ? offerState.rawMessage : localScanError?.userMessage}
+            rawMessage={
+              offerState.status === 'error'
+                ? offerState.rawMessage
+                : localScanError?.userMessage
+            }
             onRetry={handleErrorRetry}
           />
         )}

--- a/src/pages/ScanPage.tsx
+++ b/src/pages/ScanPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { PageContainer } from '../components/layout/PageContainer'
 import { IssuanceErrorCard } from '../components/issuance/IssuanceErrorCard'
-import { routes } from '../constants/routes'
+import { credentialTypeDetailsPath, routes } from '../constants/routes'
 import { useIssuanceSession } from '../hooks/useIssuanceSession'
 import type { IssuanceApiError } from '../types/issuance'
 import { issuanceUserMessage } from '../utils/issuanceErrors'
@@ -35,7 +35,12 @@ export function ScanPage() {
 
   useEffect(() => {
     if (offerState.status === 'success' && offerState.session) {
-      navigate(routes.credentialTypes)
+      const { credential_types } = offerState.session
+      if (credential_types.length === 1) {
+        navigate(credentialTypeDetailsPath(credential_types[0].credential_configuration_id))
+      } else {
+        navigate(routes.credentialTypes)
+      }
     }
   }, [offerState, navigate])
 
@@ -230,11 +235,7 @@ export function ScanPage() {
         {showErrorCard && (
           <IssuanceErrorCard
             error={offerState.status === 'error' ? offerState.apiError : null}
-            rawMessage={
-              offerState.status === 'error'
-                ? offerState.rawMessage
-                : localScanError?.userMessage
-            }
+            rawMessage={offerState.status === 'error' ? offerState.rawMessage : localScanError?.userMessage}
             onRetry={handleErrorRetry}
           />
         )}


### PR DESCRIPTION
This PR introduces navigation logic to ensure that the credential type page is only accessed when the offer contains more than one credential type.