### PR TITLE
Improve cloud-wallet-ui test coverage across API, pages, components, hooks, and utils

### DIFF
--- a/src/api/tests/client.test.ts
+++ b/src/api/tests/client.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, apiGet, apiPost } from '../client'
+
+vi.mock('../../auth/authService', () => ({
+  getBearerToken: vi.fn(async () => 'mock.jwt.token'),
+}))
+
+type MockResponse = {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+
+function makeResponse(
+  partial: Partial<MockResponse> & Pick<MockResponse, 'ok' | 'status'>
+): MockResponse {
+  return {
+    ok: partial.ok,
+    status: partial.status,
+    json: partial.json ?? (async () => ({})),
+  }
+}
+
+describe('api client', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://api.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('apiGet returns JSON for successful responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true }),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiGet<{ ok: boolean }>('/ping')).resolves.toEqual({ ok: true })
+  })
+
+  it('apiGet throws ApiError with fallback message for non-JSON error payloads', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 404,
+          json: async () => {
+            throw new Error('not json')
+          },
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiGet('/missing')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 404,
+      message: 'GET /missing failed with 404',
+    })
+  })
+
+  it('apiPost returns undefined for 204 No Content', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: true,
+          status: 204,
+          json: async () => ({}),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiPost<undefined, { x: number }>('/sessions/cancel', { x: 1 })).resolves.toBe(
+      undefined
+    )
+  })
+
+  it('apiPost throws ApiError with parsed error details', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 500,
+          json: async () => ({
+            error: 'internal_error',
+            error_description: 'Server exploded',
+          }),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiPost('/explode', { a: 1 })).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 500,
+      errorCode: 'internal_error',
+      errorDescription: 'Server exploded',
+      message: 'Server exploded',
+    })
+  })
+
+  it('maps AbortError to timeout ApiError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new DOMException('Request aborted', 'AbortError')
+      }) as unknown as typeof fetch
+    )
+
+    await expect(apiGet('/slow')).rejects.toBeInstanceOf(ApiError)
+    await expect(apiGet('/slow')).rejects.toMatchObject({ status: 408 })
+  })
+
+  it('rethrows non-timeout fetch errors unchanged', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      }) as unknown as typeof fetch
+    )
+
+    await expect(apiGet('/network')).rejects.toThrow('network down')
+  })
+
+  it('uses fallback api error message when error payload is not an object', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 400,
+          json: async () => 'plain-string-error',
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiPost('/plain-error', { x: 1 })).rejects.toMatchObject({
+      status: 400,
+      errorCode: null,
+      errorDescription: null,
+      message: 'POST /plain-error failed with 400',
+    })
+  })
+})

--- a/src/api/tests/client.test.ts
+++ b/src/api/tests/client.test.ts
@@ -80,9 +80,9 @@ describe('api client', () => {
       ) as unknown as typeof fetch
     )
 
-    await expect(apiPost<undefined, { x: number }>('/sessions/cancel', { x: 1 })).resolves.toBe(
-      undefined
-    )
+    await expect(
+      apiPost<undefined, { x: number }>('/sessions/cancel', { x: 1 })
+    ).resolves.toBe(undefined)
   })
 
   it('apiPost throws ApiError with parsed error details', async () => {

--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -127,6 +127,91 @@ describe('validateStartIssuanceResponse', () => {
     expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
   })
 
+  it('throws ContractError when issuer.display_name is neither string nor null', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      issuer: {
+        ...validStartIssuanceResponse.issuer,
+        display_name: 42,
+      },
+    }
+    expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
+  })
+
+  it('throws ContractError when tx_code.length is not number|null', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      flow: 'pre_authorized_code',
+      tx_code_required: true,
+      tx_code: { input_mode: 'numeric', length: '6', description: null },
+    }
+    expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
+  })
+
+  it('throws ContractError when display.logo exists but is not an object', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      credential_types: [
+        {
+          ...validStartIssuanceResponse.credential_types[0],
+          display: {
+            ...validStartIssuanceResponse.credential_types[0].display,
+            logo: 'https://issuer.example.eu/logo.svg',
+          },
+        },
+      ],
+    }
+    expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
+  })
+
+  it('accepts display object with only required name field', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      credential_types: [
+        {
+          ...validStartIssuanceResponse.credential_types[0],
+          display: { name: 'Only Name' },
+        },
+      ],
+    }
+    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+  })
+
+  it('accepts display.logo object without alt_text', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      credential_types: [
+        {
+          ...validStartIssuanceResponse.credential_types[0],
+          display: {
+            name: 'EU Personal ID',
+            logo: { uri: 'https://issuer.example.eu/logo.svg' },
+          },
+        },
+      ],
+    }
+    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+  })
+
+  it('accepts display.logo object with alt_text', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      credential_types: [
+        {
+          ...validStartIssuanceResponse.credential_types[0],
+          display: {
+            name: 'EU Personal ID',
+            logo: {
+              uri: 'https://issuer.example.eu/logo.svg',
+              alt_text: 'Issuer mark',
+            },
+          },
+        },
+      ],
+    }
+    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+  })
+
   it('throws ContractError when the response is null', () => {
     expect(() => validateStartIssuanceResponse(null)).toThrow(ContractError)
   })
@@ -215,6 +300,30 @@ describe('validateCredentialListResponse', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(Error)
       expect((err as Error).message).toContain('credentials[1]')
+    }
+  })
+
+  it('stringifies non-Error throws while preserving credentials index', () => {
+    const badRecord = {
+      get id() {
+        throw 'id getter failed'
+      },
+      credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
+      format: 'dc+sd-jwt',
+      issuer: 'https://issuer.example.eu',
+      status: 'active',
+      issued_at: '2026-04-08T14:35:00Z',
+      expires_at: null,
+      claims: {},
+    }
+
+    try {
+      validateCredentialListResponse({ credentials: [badRecord] })
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error)
+      expect((err as Error).message).toContain('credentials[0]')
+      expect((err as Error).message).toContain('id getter failed')
     }
   })
 

--- a/src/auth/tests/tenant.test.ts
+++ b/src/auth/tests/tenant.test.ts
@@ -88,6 +88,19 @@ describe('registerTenant', () => {
     await expect(registerTenant('Test')).rejects.toThrow('400')
   })
 
+  it('includes response body text in thrown error when available', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 409,
+      text: async () => 'tenant name already exists',
+    }))
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    await expect(registerTenant('Test')).rejects.toThrow(
+      'Tenant registration failed with HTTP 409: tenant name already exists'
+    )
+  })
+
   it('throws when tenant_id is missing from the response', async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,

--- a/src/components/issuance/tests/IssuanceErrorCard.test.tsx
+++ b/src/components/issuance/tests/IssuanceErrorCard.test.tsx
@@ -44,6 +44,8 @@ describe('IssuanceErrorCard', () => {
       />
     )
 
-    expect(screen.getByText('The transaction code is invalid. Check it and try again.')).toBeDefined()
+    expect(
+      screen.getByText('The transaction code is invalid. Check it and try again.')
+    ).toBeDefined()
   })
 })

--- a/src/components/issuance/tests/IssuanceErrorCard.test.tsx
+++ b/src/components/issuance/tests/IssuanceErrorCard.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IssuanceErrorCard } from '../IssuanceErrorCard'
+
+describe('IssuanceErrorCard', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows fallback message when both rawMessage and error are missing', () => {
+    render(<IssuanceErrorCard error={null} onRetry={() => {}} />)
+    expect(screen.getByText('An unknown error occurred.')).toBeDefined()
+  })
+
+  it('uses rawMessage over derived error message and triggers retry callback', () => {
+    const onRetry = vi.fn()
+    render(
+      <IssuanceErrorCard
+        error={{
+          httpStatus: 400,
+          error: 'invalid_request',
+          error_description: null,
+        }}
+        rawMessage="Custom message"
+        onRetry={onRetry}
+      />
+    )
+
+    expect(screen.getByText('Custom message')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Scan again' }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('derives user message from error when rawMessage is absent', () => {
+    render(
+      <IssuanceErrorCard
+        error={{
+          httpStatus: 400,
+          error: 'invalid_tx_code',
+          error_description: null,
+        }}
+        onRetry={() => {}}
+      />
+    )
+
+    expect(screen.getByText('The transaction code is invalid. Check it and try again.')).toBeDefined()
+  })
+})

--- a/src/components/issuance/tests/TxCodeInput.test.tsx
+++ b/src/components/issuance/tests/TxCodeInput.test.tsx
@@ -152,5 +152,4 @@ describe('TxCodeInput', () => {
     const alert = await screen.findByRole('alert')
     expect(alert.textContent ?? '').toContain('Please enter the transaction code.')
   })
-
 })

--- a/src/components/issuance/tests/TxCodeInput.test.tsx
+++ b/src/components/issuance/tests/TxCodeInput.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TxCodeInput } from '../TxCodeInput'
+
+describe('TxCodeInput', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('filters non-digits from numeric input before submit', async () => {
+    const onSubmit = vi.fn(async () => {})
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'numeric', length: null, description: null }}
+        sessionId="ses_1"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: '12a3' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('123')
+    })
+  })
+
+  it('shows required validation message when submitting empty code via Enter', async () => {
+    const onSubmit = vi.fn(async () => {})
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'numeric', length: null, description: null }}
+        sessionId="ses_1"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    const input = screen.getByRole('textbox')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent ?? '').toContain('Please enter the transaction code.')
+  })
+
+  it('focuses hidden input when tapping edit in boxed mode', async () => {
+    const onSubmit = vi.fn(async () => {})
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'numeric', length: 6, description: null }}
+        sessionId="ses_1"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    const hiddenInput = screen.getByRole('textbox', { hidden: true })
+    fireEvent.click(screen.getByRole('button', { name: 'Tap to edit' }))
+    expect(document.activeElement).toBe(hiddenInput)
+  })
+
+  it('submits code successfully from text mode', async () => {
+    const onSubmit = vi.fn(async () => {})
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'text', length: null, description: null }}
+        sessionId="ses_1"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'code-123')
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('code-123')
+    })
+  })
+
+  it('shows exact-length validation for text mode when length is configured', async () => {
+    const onSubmit = vi.fn(async () => {})
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'text', length: 4, description: null }}
+        sessionId="ses_1"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'abc')
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent ?? '').toContain('Code must be exactly 4 characters.')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('renders numeric placeholder with explicit digit length in non-boxed mode', () => {
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'numeric', length: 9, description: null }}
+        sessionId="ses_1"
+        onSubmit={vi.fn(async () => {})}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    expect(screen.getByPlaceholderText('Enter 9-digit code')).toBeDefined()
+  })
+
+  it('shows required message when expected length is 1 and input is empty', async () => {
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'text', length: 1, description: null }}
+        sessionId="ses_1"
+        onSubmit={vi.fn(async () => {})}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' })
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent ?? '').toContain('Please enter the transaction code.')
+  })
+
+  it('shows required message in numeric mode when expected length is 1 and input is empty', async () => {
+    render(
+      <TxCodeInput
+        txCodeSpec={{ input_mode: 'numeric', length: 1, description: null }}
+        sessionId="ses_1"
+        onSubmit={vi.fn(async () => {})}
+        onCancel={() => {}}
+        isSubmitting={false}
+      />
+    )
+
+    fireEvent.keyDown(screen.getByRole('textbox', { hidden: true }), { key: 'Enter' })
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent ?? '').toContain('Please enter the transaction code.')
+  })
+
+})

--- a/src/components/tests/Footer.test.tsx
+++ b/src/components/tests/Footer.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Footer } from '../Footer'
+import { routes } from '../../constants/routes'
+
+describe('Footer', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('calls onScanClick when scan button is pressed', () => {
+    const onScanClick = vi.fn()
+    render(
+      <MemoryRouter initialEntries={[routes.home]}>
+        <Footer onScanClick={onScanClick} scanDisabled={false} />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scan credential offer QR' }))
+    expect(onScanClick).toHaveBeenCalledOnce()
+  })
+
+  it('sets aria-current for creds link when credentials route is active', () => {
+    render(
+      <MemoryRouter initialEntries={[routes.credentials]}>
+        <Footer onScanClick={() => {}} scanDisabled={false} />
+      </MemoryRouter>
+    )
+
+    const credsLink = screen
+      .getAllByRole('link', { name: /creds/i })
+      .find((link) => link.getAttribute('aria-current') === 'page')
+    if (!credsLink) {
+      throw new Error('Expected creds link with aria-current=page')
+    }
+    expect(credsLink.getAttribute('aria-current')).toBe('page')
+  })
+
+  it('uses compact aria-label when labels are hidden', () => {
+    render(
+      <MemoryRouter initialEntries={[routes.home]}>
+        <Footer onScanClick={() => {}} scanDisabled={false} showLabels={false} />
+      </MemoryRouter>
+    )
+
+    const credsLinks = screen.getAllByRole('link', { name: 'Creds' })
+    expect(credsLinks.length).toBe(1)
+    expect(screen.queryByText('Creds')).toBeNull()
+  })
+})

--- a/src/components/tests/Header.test.tsx
+++ b/src/components/tests/Header.test.tsx
@@ -70,9 +70,7 @@ describe('Header', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Install app' }))
 
     expect(installApp).toHaveBeenCalledOnce()
-    expect(
-      screen.queryByText(/Install prompt is unavailable right now\./i)
-    ).toBeNull()
+    expect(screen.queryByText(/Install prompt is unavailable right now\./i)).toBeNull()
   })
 
   it('toggles iOS install instructions when iOS install flow is used', () => {
@@ -96,9 +94,7 @@ describe('Header', () => {
   it('shows fallback hint when install prompt is unavailable', () => {
     render(<Header />)
     fireEvent.click(screen.getByRole('button', { name: 'Install app' }))
-    expect(
-      screen.getByText(/Install prompt is unavailable right now\./i)
-    ).toBeDefined()
+    expect(screen.getByText(/Install prompt is unavailable right now\./i)).toBeDefined()
   })
 
   it('hides banner and main header when props disable them', () => {

--- a/src/components/tests/Header.test.tsx
+++ b/src/components/tests/Header.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { Header } from '../Header'
+import { usePWA } from '../../hooks/usePWA'
+
+vi.mock('../../hooks/usePWA', () => ({
+  usePWA: vi.fn(),
+}))
+
+const mockedUsePwa = vi.mocked(usePWA)
+
+describe('Header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedUsePwa.mockReturnValue({
+      installApp: vi.fn(async () => {}),
+      isInstallable: false,
+      isInstalling: false,
+      isInstalled: false,
+      isIosInstallable: false,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders installed state and disables install button', () => {
+    mockedUsePwa.mockReturnValue({
+      installApp: vi.fn(async () => {}),
+      isInstallable: false,
+      isInstalling: false,
+      isInstalled: true,
+      isIosInstallable: false,
+    })
+
+    render(<Header />)
+    const button = screen.getByRole('button', { name: 'Install app' })
+    expect(button.textContent).toBe('Installed')
+    expect(button.getAttribute('disabled')).not.toBeNull()
+  })
+
+  it('shows Installing label while installation is in progress', () => {
+    mockedUsePwa.mockReturnValue({
+      installApp: vi.fn(async () => {}),
+      isInstallable: false,
+      isInstalling: true,
+      isInstalled: false,
+      isIosInstallable: false,
+    })
+
+    render(<Header />)
+    const button = screen.getByRole('button', { name: 'Install app' })
+    expect(button.textContent).toBe('Installing...')
+    expect(button.getAttribute('disabled')).not.toBeNull()
+  })
+
+  it('calls installApp when app is installable', () => {
+    const installApp = vi.fn(async () => {})
+    mockedUsePwa.mockReturnValue({
+      installApp,
+      isInstallable: true,
+      isInstalling: false,
+      isInstalled: false,
+      isIosInstallable: false,
+    })
+
+    render(<Header />)
+    fireEvent.click(screen.getByRole('button', { name: 'Install app' }))
+
+    expect(installApp).toHaveBeenCalledOnce()
+    expect(
+      screen.queryByText(/Install prompt is unavailable right now\./i)
+    ).toBeNull()
+  })
+
+  it('toggles iOS install instructions when iOS install flow is used', () => {
+    mockedUsePwa.mockReturnValue({
+      installApp: vi.fn(async () => {}),
+      isInstallable: false,
+      isInstalling: false,
+      isInstalled: false,
+      isIosInstallable: true,
+    })
+
+    render(<Header />)
+    const button = screen.getByRole('button', { name: 'Install app' })
+    fireEvent.click(button)
+    expect(screen.getByText(/To install on iOS:/i)).toBeDefined()
+
+    fireEvent.click(button)
+    expect(screen.queryByText(/To install on iOS:/i)).toBeNull()
+  })
+
+  it('shows fallback hint when install prompt is unavailable', () => {
+    render(<Header />)
+    fireEvent.click(screen.getByRole('button', { name: 'Install app' }))
+    expect(
+      screen.getByText(/Install prompt is unavailable right now\./i)
+    ).toBeDefined()
+  })
+
+  it('hides banner and main header when props disable them', () => {
+    render(<Header hidePwaBanner showMainHeader={false} />)
+    expect(screen.queryByRole('button', { name: 'Install app' })).toBeNull()
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull()
+  })
+})

--- a/src/constants/tests/routes.test.ts
+++ b/src/constants/tests/routes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  credentialDetailPath,
+  credentialTypeDetailsPath,
+  issuanceSuccessPath,
+} from '../routes'
+
+describe('routes helpers', () => {
+  it('builds credential type details path with encoding', () => {
+    expect(credentialTypeDetailsPath('a/b')).toBe('/credential-types/a%2Fb')
+  })
+
+  it('builds credential detail path with encoding', () => {
+    expect(credentialDetailPath('id with space')).toBe('/credentials/id%20with%20space')
+  })
+
+  it('builds issuance success path with credential id', () => {
+    expect(issuanceSuccessPath('cred-1')).toBe('/issuance/success/cred-1')
+  })
+
+  it('builds issuance success path without credential id', () => {
+    expect(issuanceSuccessPath()).toBe('/issuance/success')
+  })
+})

--- a/src/hooks/test/usePWA.test.ts
+++ b/src/hooks/test/usePWA.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePWA } from '../usePWA'
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    configurable: true,
+    value: userAgent,
+  })
+}
+
+function setStandaloneFlag(value?: boolean) {
+  Object.defineProperty(window.navigator, 'standalone', {
+    configurable: true,
+    value,
+  })
+}
+
+function setMatchMedia(matchesStandalone: boolean, matchesMinimalUi = false) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn((query: string) => ({
+      matches:
+        query === '(display-mode: standalone)'
+          ? matchesStandalone
+          : query === '(display-mode: minimal-ui)'
+            ? matchesMinimalUi
+            : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+describe('usePWA', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
+    setStandaloneFlag(undefined)
+    setMatchMedia(false, false)
+  })
+
+  it('is not installable by default when no prompt event exists', () => {
+    const { result } = renderHook(() => usePWA())
+    expect(result.current.isInstallable).toBe(false)
+    expect(result.current.isInstalled).toBe(false)
+    expect(result.current.isIosInstallable).toBe(false)
+  })
+
+  it('installApp no-ops when no deferred prompt exists', async () => {
+    const { result } = renderHook(() => usePWA())
+
+    await act(async () => {
+      await result.current.installApp()
+    })
+
+    expect(result.current.isInstalling).toBe(false)
+    expect(result.current.isInstallable).toBe(false)
+  })
+
+  it('becomes installable after beforeinstallprompt and resets after installApp', async () => {
+    const prompt = vi.fn(async () => {})
+    const event = new Event('beforeinstallprompt') as Event & {
+      prompt: () => Promise<void>
+      userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>
+    }
+    event.prompt = prompt
+    event.userChoice = Promise.resolve({ outcome: 'accepted', platform: 'web' })
+
+    const { result } = renderHook(() => usePWA())
+    act(() => {
+      window.dispatchEvent(event)
+    })
+
+    expect(result.current.isInstallable).toBe(true)
+
+    await act(async () => {
+      await result.current.installApp()
+    })
+
+    expect(prompt).toHaveBeenCalledOnce()
+    expect(result.current.isInstallable).toBe(false)
+    expect(result.current.isInstalling).toBe(false)
+  })
+
+  it('marks app as installed when appinstalled event fires', async () => {
+    const { result } = renderHook(() => usePWA())
+
+    act(() => {
+      window.dispatchEvent(new Event('appinstalled'))
+    })
+
+    await waitFor(() => {
+      expect(result.current.isInstalled).toBe(true)
+      expect(result.current.isInstallable).toBe(false)
+    })
+  })
+
+  it('exposes iOS installable state when on iPhone and not standalone', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)')
+    const { result } = renderHook(() => usePWA())
+    expect(result.current.isIosInstallable).toBe(true)
+  })
+})

--- a/src/pages/tests/CredentialDetailPage.test.tsx
+++ b/src/pages/tests/CredentialDetailPage.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { routes } from '../../constants/routes'
+import { CredentialDetailPage } from '../CredentialDetailPage'
+import { useCredentialDetail } from '../../hooks/useCredentialDetail'
+import type { CredentialRecord } from '../../types/credential'
+
+vi.mock('../../hooks/useCredentialDetail', () => ({
+  useCredentialDetail: vi.fn(),
+}))
+
+const mockedUseCredentialDetail = vi.mocked(useCredentialDetail)
+
+function sampleCredential(overrides: Partial<CredentialRecord> = {}): CredentialRecord {
+  return {
+    id: 'cred-1',
+    credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
+    format: 'dc+sd-jwt',
+    issuer: 'https://issuer.example.org',
+    status: 'active',
+    issued_at: '2026-04-08T14:35:00Z',
+    expires_at: null,
+    claims: {
+      given_name: 'Jane',
+      family_name: 'Doe',
+      id: '12345',
+    },
+    ...overrides,
+  }
+}
+
+describe('CredentialDetailPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  it('redirects to credentials route when credential id param is missing', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: null,
+      loading: false,
+      error: null,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/unknown']}>
+        <Routes>
+          <Route path="*" element={<CredentialDetailPage />} />
+          <Route path={routes.credentials} element={<div>Credentials list</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Credentials list')).toBeDefined()
+  })
+
+  it('renders loading state while detail hook is pending', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: null,
+      loading: true,
+      error: null,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/credentials/cred-1']}>
+        <Routes>
+          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Loading…')).toBeDefined()
+  })
+
+  it('renders error state and navigates back to credentials', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: null,
+      loading: false,
+      error: new Error('Detail fetch failed'),
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/credentials/cred-1']}>
+        <Routes>
+          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route path={routes.credentials} element={<div>Credentials list</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Could not open this credential.')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Back to Credentials' }))
+    expect(screen.getByText('Credentials list')).toBeDefined()
+  })
+
+  it('reveals and hides fields individually and via show-all toggle', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: sampleCredential(),
+      loading: false,
+      error: null,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/credentials/cred-1']}>
+        <Routes>
+          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    // Initially hidden
+    expect(screen.getByLabelText('Given Name hidden')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Show Given Name' }))
+    expect(screen.getByLabelText('Jane')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Given Name' }))
+    expect(screen.getByLabelText('Given Name hidden')).toBeDefined()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all fields' }))
+    expect(screen.getByRole('button', { name: 'Hide all fields' })).toBeDefined()
+    expect(screen.getByLabelText('Doe')).toBeDefined()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide all fields' }))
+    expect(screen.getByLabelText('Family Name hidden')).toBeDefined()
+  })
+
+  it('renders object claim values as formatted JSON strings when revealed', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: sampleCredential({
+        claims: {
+          address: { street: 'Main', city: 'Berlin' },
+        },
+      }),
+      loading: false,
+      error: null,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/credentials/cred-1']}>
+        <Routes>
+          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show Address' }))
+    expect(screen.getByLabelText(/"street": "Main"/)).toBeDefined()
+  })
+
+  it('shows empty-details message when claims are empty', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: sampleCredential({ claims: {} }),
+      loading: false,
+      error: null,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/credentials/cred-1']}>
+        <Routes>
+          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('No details available for this credential.')).toBeDefined()
+  })
+
+  it('renders em-dash for null claim values when revealed', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: sampleCredential({ claims: { middle_name: null } }),
+      loading: false,
+      error: null,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/credentials/cred-1']}>
+        <Routes>
+          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show Middle Name' }))
+    expect(screen.getByLabelText('—')).toBeDefined()
+  })
+
+  it('navigates back from header control', () => {
+    mockedUseCredentialDetail.mockReturnValue({
+      credential: sampleCredential(),
+      loading: false,
+      error: null,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/credentials/cred-1']}>
+        <Routes>
+          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route path={routes.credentials} element={<div>Credentials list</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to credentials' }))
+    expect(screen.getByText('Credentials list')).toBeDefined()
+  })
+})

--- a/src/pages/tests/CredentialDetailPage.test.tsx
+++ b/src/pages/tests/CredentialDetailPage.test.tsx
@@ -82,7 +82,10 @@ describe('CredentialDetailPage', () => {
     render(
       <MemoryRouter initialEntries={['/credentials/cred-1']}>
         <Routes>
-          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route
+            path={`${routes.credentials}/:credentialId`}
+            element={<CredentialDetailPage />}
+          />
         </Routes>
       </MemoryRouter>
     )
@@ -100,7 +103,10 @@ describe('CredentialDetailPage', () => {
     render(
       <MemoryRouter initialEntries={['/credentials/cred-1']}>
         <Routes>
-          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route
+            path={`${routes.credentials}/:credentialId`}
+            element={<CredentialDetailPage />}
+          />
           <Route path={routes.credentials} element={<div>Credentials list</div>} />
         </Routes>
       </MemoryRouter>
@@ -121,7 +127,10 @@ describe('CredentialDetailPage', () => {
     render(
       <MemoryRouter initialEntries={['/credentials/cred-1']}>
         <Routes>
-          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route
+            path={`${routes.credentials}/:credentialId`}
+            element={<CredentialDetailPage />}
+          />
         </Routes>
       </MemoryRouter>
     )
@@ -155,7 +164,10 @@ describe('CredentialDetailPage', () => {
     render(
       <MemoryRouter initialEntries={['/credentials/cred-1']}>
         <Routes>
-          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route
+            path={`${routes.credentials}/:credentialId`}
+            element={<CredentialDetailPage />}
+          />
         </Routes>
       </MemoryRouter>
     )
@@ -174,7 +186,10 @@ describe('CredentialDetailPage', () => {
     render(
       <MemoryRouter initialEntries={['/credentials/cred-1']}>
         <Routes>
-          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route
+            path={`${routes.credentials}/:credentialId`}
+            element={<CredentialDetailPage />}
+          />
         </Routes>
       </MemoryRouter>
     )
@@ -192,7 +207,10 @@ describe('CredentialDetailPage', () => {
     render(
       <MemoryRouter initialEntries={['/credentials/cred-1']}>
         <Routes>
-          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route
+            path={`${routes.credentials}/:credentialId`}
+            element={<CredentialDetailPage />}
+          />
         </Routes>
       </MemoryRouter>
     )
@@ -211,7 +229,10 @@ describe('CredentialDetailPage', () => {
     render(
       <MemoryRouter initialEntries={['/credentials/cred-1']}>
         <Routes>
-          <Route path={`${routes.credentials}/:credentialId`} element={<CredentialDetailPage />} />
+          <Route
+            path={`${routes.credentials}/:credentialId`}
+            element={<CredentialDetailPage />}
+          />
           <Route path={routes.credentials} element={<div>Credentials list</div>} />
         </Routes>
       </MemoryRouter>

--- a/src/pages/tests/CredentialTypeDetailsPage.test.tsx
+++ b/src/pages/tests/CredentialTypeDetailsPage.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
@@ -7,6 +7,7 @@ import { CredentialTypeDetailsPage } from '../CredentialTypeDetailsPage'
 import { routes, issuanceSuccessPath } from '../../constants/routes'
 import type { StartIssuanceResponse, ConsentResponse } from '../../types/issuance'
 import type { SseStreamStatus } from '../../hooks/useSseStream'
+import { ApiError } from '../../api/client'
 
 const mockNavigate = vi.fn()
 
@@ -95,6 +96,16 @@ function renderPage(initialPath = '/credential-types/identity_credential') {
           path={routes.credentialTypeDetails}
           element={<CredentialTypeDetailsPage />}
         />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+function renderRawPath(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="*" element={<CredentialTypeDetailsPage />} />
       </Routes>
     </MemoryRouter>
   )
@@ -230,6 +241,7 @@ describe('CredentialTypeDetailsPage', () => {
     await waitFor(() => {
       expect(mockSubmitTxCode).toHaveBeenCalledWith('ses_123', '123456')
     })
+    expect(screen.getByText('Exchanging authorization token…')).toBeTruthy()
   })
 
   it('shows error when tx code submission fails (e.g. invalid_tx_code)', async () => {
@@ -348,6 +360,71 @@ describe('CredentialTypeDetailsPage', () => {
     })
   })
 
+  it('redirects when optionId route param is missing', async () => {
+    renderRawPath('/credential-types')
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes, {
+        replace: true,
+      })
+    })
+  })
+
+  it('redirects when there is no offer session in state', async () => {
+    mockOfferState.offer = undefined
+    renderPage()
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes, {
+        replace: true,
+      })
+    })
+  })
+
+  it('does not re-handle identical SSE status on rerender', async () => {
+    mockStreamStatus = {
+      status: 'completed',
+      credentialIds: ['cred-uuid-1'],
+      credentialTypes: ['identity_credential'],
+    }
+
+    const view = renderPage()
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledTimes(1)
+    })
+
+    mockStreamStatus = {
+      status: 'completed',
+      credentialIds: ['cred-uuid-1'],
+      credentialTypes: ['identity_credential'],
+    }
+    view.rerender(
+      <MemoryRouter initialEntries={['/credential-types/identity_credential']}>
+        <Routes>
+          <Route
+            path={routes.credentialTypeDetails}
+            element={<CredentialTypeDetailsPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores immediate second Issue VC click while consent is in-flight', () => {
+    mockSubmitConsent.mockReturnValue(
+      new Promise<ConsentResponse>(() => {
+        // Keep unresolved so the in-flight guard is exercised.
+      })
+    )
+
+    renderPage()
+    const issueButton = screen.getByRole('button', { name: 'Issue VC' })
+    fireEvent.click(issueButton)
+    fireEvent.click(issueButton)
+
+    expect(mockSubmitConsent).toHaveBeenCalledTimes(1)
+  })
+
   it('shows failure overlay when SSE failed event received', async () => {
     mockStreamStatus = {
       status: 'failed',
@@ -389,5 +466,358 @@ describe('CredentialTypeDetailsPage', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('falls back to issuer host when display_name is missing', () => {
+    mockOfferState.offer = buildOffer({
+      issuer: {
+        credential_issuer: 'https://issuer-host.example.org',
+        display_name: null,
+        logo_uri: null,
+      },
+    })
+    renderPage()
+    expect(screen.getByText('issuer-host.example.org')).toBeTruthy()
+  })
+
+  it('shows failure when redirect action has no authorization_url', async () => {
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'redirect',
+      authorization_url: null,
+    } as unknown as ConsentResponse)
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Authorization URL missing from server response.')
+      ).toBeTruthy()
+    })
+  })
+
+  it('redirects browser when consent next_action is redirect with authorization_url', async () => {
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'redirect',
+      authorization_url: 'https://auth.example.org/authorize?x=1',
+    } as ConsentResponse)
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Processing…')).toBeTruthy()
+    })
+  })
+
+  it('navigates to scan when consent result is rejected', async () => {
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'rejected',
+    } as ConsentResponse)
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(routes.scan, { replace: true })
+    })
+  })
+
+  it('navigates back to credential types from top back button', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes)
+  })
+
+  it('still navigates away when cancelSession fails during cancel action', async () => {
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'none',
+    } as ConsentResponse)
+    mockCancelSession.mockRejectedValueOnce(new Error('cancel failed'))
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes)
+    })
+  })
+
+  it('prevents duplicate Issue VC calls while consent is in flight', async () => {
+    mockSubmitConsent.mockReturnValue(
+      new Promise<ConsentResponse>(() => {
+        // Intentionally unresolved to keep request in-flight.
+      })
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    const issueButton = screen.getByRole('button', { name: 'Issue VC' })
+    await user.click(issueButton)
+    await user.click(issueButton)
+
+    expect(mockSubmitConsent).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows mapped message when consent fails with ApiError', async () => {
+    mockSubmitConsent.mockRejectedValueOnce(
+      new ApiError(401, 'Unauthorized', {
+        errorCode: 'unauthorized',
+        errorDescription: null,
+      })
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Authentication failed. Please restart the flow and try again.')
+      ).toBeTruthy()
+    })
+  })
+
+  it('prevents duplicate top-level cancel action while cancel is in flight', async () => {
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'none',
+    } as ConsentResponse)
+    mockCancelSession.mockReturnValue(
+      new Promise<void>(() => {
+        // Intentionally unresolved to keep request in-flight.
+      })
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+
+    const cancelButton = screen.getAllByRole('button', { name: 'Cancel' })[0]
+    await user.click(cancelButton)
+    await user.click(cancelButton)
+
+    expect(mockCancelSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows tx-code spec error when server asks for tx code without tx_code payload', async () => {
+    mockOfferState.offer = buildOffer({
+      flow: 'pre_authorized_code',
+      tx_code_required: true,
+      tx_code: null,
+    })
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'provide_tx_code',
+    } as ConsentResponse)
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Server requested a transaction code but did not provide the code spec/i
+        )
+      ).toBeTruthy()
+    })
+  })
+
+  it('still navigates when tx-code cancel API fails', async () => {
+    mockOfferState.offer = buildOffer({
+      flow: 'pre_authorized_code',
+      tx_code_required: true,
+      tx_code: { input_mode: 'numeric', length: 6, description: null },
+    })
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'provide_tx_code',
+    } as ConsentResponse)
+    mockCancelSession.mockRejectedValueOnce(new Error('cancel failed'))
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+    await waitFor(() => {
+      expect(screen.getByText('Transaction Code Required')).toBeTruthy()
+    })
+
+    const cancelButtons = screen.getAllByRole('button', { name: 'Cancel' })
+    await user.click(cancelButtons[0])
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes)
+    })
+  })
+
+  it('prevents duplicate tx-code submission while submit is in flight', async () => {
+    const offerWithTxCode = buildOffer({
+      flow: 'pre_authorized_code',
+      tx_code_required: true,
+      tx_code: { input_mode: 'numeric', length: 6, description: null },
+    })
+    mockOfferState.offer = offerWithTxCode
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'provide_tx_code',
+    } as ConsentResponse)
+
+    mockSubmitTxCode.mockReturnValue(
+      new Promise<{ session_id: string }>(() => {
+        // Intentionally unresolved to keep request in-flight.
+      })
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+    await waitFor(() => {
+      expect(screen.getByText('Transaction Code Required')).toBeTruthy()
+    })
+
+    const hiddenInput = screen.getByRole('textbox', { hidden: true })
+    await user.type(hiddenInput, '123456')
+    fireEvent.keyDown(hiddenInput, { key: 'Enter' })
+    fireEvent.keyDown(hiddenInput, { key: 'Enter' })
+
+    expect(mockSubmitTxCode).toHaveBeenCalledTimes(1)
+  })
+
+  it('prevents duplicate tx-code cancellation while cancel request is in flight', async () => {
+    const offerWithTxCode = buildOffer({
+      flow: 'pre_authorized_code',
+      tx_code_required: true,
+      tx_code: { input_mode: 'numeric', length: 6, description: null },
+    })
+    mockOfferState.offer = offerWithTxCode
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'provide_tx_code',
+    } as ConsentResponse)
+
+    mockCancelSession.mockReturnValue(
+      new Promise<void>(() => {
+        // Intentionally unresolved to keep request in-flight.
+      })
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+    await waitFor(() => {
+      expect(screen.getByText('Transaction Code Required')).toBeTruthy()
+    })
+
+    const cancelButtons = screen.getAllByRole('button', { name: 'Cancel' })
+    await user.click(cancelButtons[0])
+    await user.click(cancelButtons[0])
+
+    expect(mockCancelSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call cancelSession when cancelling from hidden overlay state', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(mockCancelSession).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes)
+  })
+
+  it('restarts flow from failure overlay scan-again action', async () => {
+    mockSubmitConsent.mockRejectedValueOnce(new Error('Network error'))
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeTruthy()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Scan again' }))
+
+    expect(mockOfferState.clear).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith(routes.scan, { replace: true })
+  })
+
+  it('shows fallback tx-code error message when submission rejects with non-Error', async () => {
+    const offerWithTxCode = buildOffer({
+      flow: 'pre_authorized_code',
+      tx_code_required: true,
+      tx_code: { input_mode: 'numeric', length: 6, description: null },
+    })
+    mockOfferState.offer = offerWithTxCode
+
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'provide_tx_code',
+    } as ConsentResponse)
+    mockSubmitTxCode.mockRejectedValueOnce('bad tx')
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+    await waitFor(() => {
+      expect(screen.getByText('Transaction Code Required')).toBeTruthy()
+    })
+
+    const hiddenInput = screen.getByRole('textbox', { hidden: true })
+    await user.type(hiddenInput, '123456')
+    await user.click(screen.getByRole('button', { name: 'Submit Code' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Invalid transaction code. Please check and try again.')
+      ).toBeTruthy()
+    })
+  })
+
+  it('uses fallback message when SSE failed event has no errorDescription', async () => {
+    mockStreamStatus = {
+      status: 'failed',
+      error: 'internal_error',
+      errorDescription: null,
+      step: 'requesting_credential',
+    }
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Issuance failed at step "requesting_credential": internal_error'
+        )
+      ).toBeTruthy()
+    })
+  })
+
+  it('renders only core display rows when optional display fields are absent', () => {
+    mockOfferState.offer = buildOffer({
+      credential_types: [
+        {
+          credential_configuration_id: 'identity_credential',
+          format: 'vc+sd-jwt',
+          display: { name: 'Identity Credential' },
+        },
+      ],
+    })
+
+    renderPage()
+    expect(screen.getByText('Credential Configuration ID')).toBeTruthy()
+    expect(screen.queryByText('Description')).toBeNull()
+    expect(screen.queryByText('Background Color')).toBeNull()
+    expect(screen.queryByText('Text Color')).toBeNull()
+    expect(screen.queryByText('Logo URI')).toBeNull()
+    expect(screen.queryByText('Logo Alt Text')).toBeNull()
   })
 })

--- a/src/pages/tests/CredentialTypesPage.test.tsx
+++ b/src/pages/tests/CredentialTypesPage.test.tsx
@@ -69,7 +69,11 @@ vi.mock('../../state/issuance.state', () => ({
 }))
 
 vi.mock('../../components/Footer', () => ({
-  Footer: () => <div data-testid="footer" />,
+  Footer: ({ onScanClick }: { onScanClick: () => void }) => (
+    <button type="button" onClick={onScanClick}>
+      Footer Scan
+    </button>
+  ),
 }))
 
 function renderPage() {
@@ -197,5 +201,19 @@ describe('CredentialTypesPage', () => {
         replace: true,
       })
     })
+  })
+
+  it('navigates to scan from header back button', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    expect(mockNavigate).toHaveBeenCalledWith(routes.scan)
+  })
+
+  it('navigates to scan when footer scan is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Footer Scan' }))
+    expect(mockNavigate).toHaveBeenCalledWith(routes.scan)
   })
 })

--- a/src/pages/tests/CredentialsPage.test.tsx
+++ b/src/pages/tests/CredentialsPage.test.tsx
@@ -74,6 +74,25 @@ describe('CredentialsPage', () => {
     ).toBeDefined()
   })
 
+  it('navigates to scan page when empty-state CTA is clicked', () => {
+    mockedUseCredentials.mockReturnValue({
+      credentials: [],
+      loading: false,
+    })
+
+    render(
+      <MemoryRouter initialEntries={[routes.credentials]}>
+        <Routes>
+          <Route path={routes.credentials} element={<CredentialsPage />} />
+          <Route path={routes.scan} element={<div>Scan page</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add your first Credential' }))
+    expect(screen.getByText('Scan page')).toBeDefined()
+  })
+
   it('renders credentials list using the last segment of credential_configuration_id as title', () => {
     mockedUseCredentials.mockReturnValue({
       loading: false,
@@ -150,5 +169,60 @@ describe('CredentialsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /mDL/i }))
 
     expect(screen.getByText('Credential details view')).toBeDefined()
+  })
+
+  it('shows loading state while credentials are being fetched', () => {
+    mockedUseCredentials.mockReturnValue({
+      loading: true,
+      credentials: [],
+    })
+
+    render(
+      <MemoryRouter initialEntries={[routes.credentials]}>
+        <Routes>
+          <Route path={routes.credentials} element={<CredentialsPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Loading credentials…')).toBeDefined()
+  })
+
+  it('navigates to home from header back button', () => {
+    mockedUseCredentials.mockReturnValue({
+      loading: false,
+      credentials: [],
+    })
+
+    render(
+      <MemoryRouter initialEntries={[routes.credentials]}>
+        <Routes>
+          <Route path={routes.credentials} element={<CredentialsPage />} />
+          <Route path={routes.home} element={<div>Home page</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to home' }))
+    expect(screen.getByText('Home page')).toBeDefined()
+  })
+
+  it('navigates to scan page from footer scan button', () => {
+    mockedUseCredentials.mockReturnValue({
+      loading: false,
+      credentials: [],
+    })
+
+    render(
+      <MemoryRouter initialEntries={[routes.credentials]}>
+        <Routes>
+          <Route path={routes.credentials} element={<CredentialsPage />} />
+          <Route path={routes.scan} element={<div>Scan destination</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scan credential offer QR' }))
+    expect(screen.getByText('Scan destination')).toBeDefined()
   })
 })

--- a/src/pages/tests/RegistrationPage.test.tsx
+++ b/src/pages/tests/RegistrationPage.test.tsx
@@ -99,7 +99,10 @@ describe('RegistrationPage', () => {
   })
 
   it('ignores repeated register clicks while request is in flight', async () => {
-    let resolveRegistration: (value: { tenant_id: string; name: string }) => void = () => {}
+    let resolveRegistration: (value: {
+      tenant_id: string
+      name: string
+    }) => void = () => {}
     mockedRegisterTenant.mockReturnValue(
       new Promise((resolve) => {
         resolveRegistration = resolve

--- a/src/pages/tests/RegistrationPage.test.tsx
+++ b/src/pages/tests/RegistrationPage.test.tsx
@@ -99,9 +99,7 @@ describe('RegistrationPage', () => {
   })
 
   it('ignores repeated register clicks while request is in flight', async () => {
-    let resolveRegistration:
-      | ((value: { tenant_id: string; name: string }) => void)
-      | null = null
+    let resolveRegistration: (value: { tenant_id: string; name: string }) => void = () => {}
     mockedRegisterTenant.mockReturnValue(
       new Promise((resolve) => {
         resolveRegistration = resolve
@@ -115,7 +113,7 @@ describe('RegistrationPage', () => {
 
     expect(mockedRegisterTenant).toHaveBeenCalledTimes(1)
 
-    resolveRegistration?.({ tenant_id: 'tenant-1', name: 'DATEV Cloud Wallet' })
+    resolveRegistration({ tenant_id: 'tenant-1', name: 'DATEV Cloud Wallet' })
     await waitFor(() => {
       expect(mockedInitAuth).toHaveBeenCalledOnce()
     })

--- a/src/pages/tests/RegistrationPage.test.tsx
+++ b/src/pages/tests/RegistrationPage.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { routes } from '../../constants/routes'
+import { RegistrationPage } from '../RegistrationPage'
+import { initAuth } from '../../auth/authService'
+import { getStoredTenantId, registerTenant, storeTenantId } from '../../auth/tenant'
+
+const navigateMock = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+vi.mock('../../auth/authService', () => ({
+  initAuth: vi.fn(),
+}))
+
+vi.mock('../../auth/tenant', () => ({
+  DEFAULT_TENANT_NAME: 'DATEV Cloud Wallet',
+  getStoredTenantId: vi.fn(),
+  registerTenant: vi.fn(),
+  storeTenantId: vi.fn(),
+}))
+
+const mockedInitAuth = vi.mocked(initAuth)
+const mockedGetStoredTenantId = vi.mocked(getStoredTenantId)
+const mockedRegisterTenant = vi.mocked(registerTenant)
+const mockedStoreTenantId = vi.mocked(storeTenantId)
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[routes.registration]}>
+      <RegistrationPage />
+    </MemoryRouter>
+  )
+}
+
+describe('RegistrationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedGetStoredTenantId.mockReturnValue(null)
+    mockedRegisterTenant.mockResolvedValue({
+      tenant_id: 'tenant-1',
+      name: 'DATEV Cloud Wallet',
+    })
+    mockedInitAuth.mockResolvedValue('tenant-1')
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('registers tenant when no tenant is stored and then navigates home', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Register' }))
+
+    await waitFor(() => {
+      expect(mockedRegisterTenant).toHaveBeenCalledOnce()
+      expect(mockedStoreTenantId).toHaveBeenCalledWith('tenant-1')
+      expect(mockedInitAuth).toHaveBeenCalledOnce()
+      expect(navigateMock).toHaveBeenCalledWith(routes.home, { replace: true })
+    })
+  })
+
+  it('skips tenant registration when tenant id already exists', async () => {
+    mockedGetStoredTenantId.mockReturnValue('existing-tenant')
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Register' }))
+
+    await waitFor(() => {
+      expect(mockedRegisterTenant).not.toHaveBeenCalled()
+      expect(mockedStoreTenantId).not.toHaveBeenCalled()
+      expect(mockedInitAuth).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('shows backend error message when registration fails with Error', async () => {
+    mockedRegisterTenant.mockRejectedValue(new Error('Could not register tenant'))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Register' }))
+
+    expect(await screen.findByText('Could not register tenant')).toBeDefined()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('shows fallback error message for non-Error rejection values', async () => {
+    mockedRegisterTenant.mockRejectedValue('bad response')
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Register' }))
+
+    expect(await screen.findByText('Tenant registration failed.')).toBeDefined()
+  })
+
+  it('ignores repeated register clicks while request is in flight', async () => {
+    let resolveRegistration: ((value: { tenant_id: string; name: string }) => void) | null = null
+    mockedRegisterTenant.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRegistration = resolve
+      })
+    )
+
+    renderPage()
+    const registerButton = screen.getByRole('button', { name: 'Register' })
+    fireEvent.click(registerButton)
+    fireEvent.click(registerButton)
+
+    expect(mockedRegisterTenant).toHaveBeenCalledTimes(1)
+
+    resolveRegistration?.({ tenant_id: 'tenant-1', name: 'DATEV Cloud Wallet' })
+    await waitFor(() => {
+      expect(mockedInitAuth).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('returns early from handler when already registering', async () => {
+    mockedRegisterTenant.mockReturnValue(new Promise(() => {}))
+
+    renderPage()
+    const registerButton = screen.getByRole('button', { name: 'Register' })
+    fireEvent.click(registerButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Registering...' })).toBeDefined()
+    })
+
+    const forcedEnabledButton = screen.getByRole('button', {
+      name: 'Registering...',
+    }) as HTMLButtonElement
+    forcedEnabledButton.disabled = false
+    fireEvent.click(forcedEnabledButton)
+
+    expect(mockedRegisterTenant).toHaveBeenCalledTimes(1)
+    expect(mockedInitAuth).not.toHaveBeenCalled()
+  })
+})

--- a/src/pages/tests/RegistrationPage.test.tsx
+++ b/src/pages/tests/RegistrationPage.test.tsx
@@ -10,7 +10,8 @@ import { getStoredTenantId, registerTenant, storeTenantId } from '../../auth/ten
 const navigateMock = vi.fn()
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
   return {
     ...actual,
     useNavigate: () => navigateMock,
@@ -98,7 +99,9 @@ describe('RegistrationPage', () => {
   })
 
   it('ignores repeated register clicks while request is in flight', async () => {
-    let resolveRegistration: ((value: { tenant_id: string; name: string }) => void) | null = null
+    let resolveRegistration:
+      | ((value: { tenant_id: string; name: string }) => void)
+      | null = null
     mockedRegisterTenant.mockReturnValue(
       new Promise((resolve) => {
         resolveRegistration = resolve

--- a/src/state/tests/issuance.state.test.tsx
+++ b/src/state/tests/issuance.state.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  CredentialOfferProvider,
+  useCredentialOfferState,
+} from '../issuance.state'
+
+function HookConsumer() {
+  const state = useCredentialOfferState()
+  return <div>{state.status}</div>
+}
+
+function OutsideConsumer() {
+  useCredentialOfferState()
+  return <div>outside</div>
+}
+
+describe('useCredentialOfferState', () => {
+  it('throws when used outside provider', () => {
+    expect(() => render(<OutsideConsumer />)).toThrow(
+      'useCredentialOfferState must be used within CredentialOfferProvider'
+    )
+  })
+
+  it('provides default idle state inside provider', () => {
+    render(
+      <CredentialOfferProvider>
+        <HookConsumer />
+      </CredentialOfferProvider>
+    )
+    expect(screen.getByText('idle')).toBeDefined()
+  })
+})

--- a/src/state/tests/issuance.state.test.tsx
+++ b/src/state/tests/issuance.state.test.tsx
@@ -1,10 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import {
-  CredentialOfferProvider,
-  useCredentialOfferState,
-} from '../issuance.state'
+import { CredentialOfferProvider, useCredentialOfferState } from '../issuance.state'
 
 function HookConsumer() {
   const state = useCredentialOfferState()

--- a/src/utils/tests/credentialDisplay.test.ts
+++ b/src/utils/tests/credentialDisplay.test.ts
@@ -55,6 +55,10 @@ describe('issuerDisplayLabel', () => {
     expect(issuerDisplayLabel('did:example:123')).toBe('did:example:123')
   })
 
+  it('returns raw string for malformed URL input', () => {
+    expect(issuerDisplayLabel('not a valid URL %%')).toBe('not a valid URL %%')
+  })
+
   it('returns host including port when present', () => {
     expect(issuerDisplayLabel('https://issuer.example.com:8443/oid4vci')).toBe(
       'issuer.example.com:8443'

--- a/src/utils/tests/credentialOffer.test.ts
+++ b/src/utils/tests/credentialOffer.test.ts
@@ -108,4 +108,66 @@ describe('parseCredentialOfferInput', () => {
     )
     expect(parsed).not.toBeNull()
   })
+
+  it('rejects credential_offer objects with invalid credential_configuration_ids types', () => {
+    const offer = encodeURIComponent(
+      JSON.stringify({
+        credential_issuer: 'https://issuer.example.com',
+        credential_configuration_ids: ['valid-id', 123],
+      })
+    )
+    const input = `openid-credential-offer://?credential_offer=${offer}`
+
+    expect(parseCredentialOfferInput(input)).toBeNull()
+  })
+
+  it('accepts allowlisted hosts regardless of path shape', () => {
+    vi.stubEnv('VITE_ALLOWED_CREDENTIAL_OFFER_HOSTS', 'issuer.example.com')
+    const parsed = parseCredentialOfferInput('https://issuer.example.com/not-an-offer-path')
+    expect(parsed).not.toBeNull()
+  })
+
+  it('rejects openid-credential-offer URI with insecure credential_offer_uri', () => {
+    const input =
+      'openid-credential-offer://?credential_offer_uri=' +
+      encodeURIComponent('http://issuer.example.com/credential-offer/abc')
+    expect(parseCredentialOfferInput(input)).toBeNull()
+  })
+
+  it('rejects openid-credential-offer URI with no params', () => {
+    expect(parseCredentialOfferInput('openid-credential-offer://')).toBeNull()
+  })
+
+  it('rejects openid-credential-offer URI with unrelated params only', () => {
+    expect(parseCredentialOfferInput('openid-credential-offer://?foo=bar')).toBeNull()
+  })
+
+  it('rejects credential_offer payloads that decode to non-objects', () => {
+    const payload = encodeURIComponent('"just-a-string"')
+    expect(
+      parseCredentialOfferInput(`openid-credential-offer://?credential_offer=${payload}`)
+    ).toBeNull()
+  })
+
+  it('rejects malformed encoded credential_offer payload', () => {
+    expect(
+      parseCredentialOfferInput('openid-credential-offer://?credential_offer=%E0%A4%A')
+    ).toBeNull()
+  })
+
+  it('rejects unsupported URL schemes', () => {
+    expect(parseCredentialOfferInput('ftp://issuer.example.com/credential-offer/1')).toBeNull()
+  })
+
+  it('rejects credential_offer payload with invalid credential_issuer URL', () => {
+    const offer = encodeURIComponent(
+      JSON.stringify({
+        credential_issuer: 'not-a-valid-url',
+        credential_configuration_ids: ['MyCredential'],
+      })
+    )
+    expect(
+      parseCredentialOfferInput(`openid-credential-offer://?credential_offer=${offer}`)
+    ).toBeNull()
+  })
 })

--- a/src/utils/tests/credentialOffer.test.ts
+++ b/src/utils/tests/credentialOffer.test.ts
@@ -123,7 +123,9 @@ describe('parseCredentialOfferInput', () => {
 
   it('accepts allowlisted hosts regardless of path shape', () => {
     vi.stubEnv('VITE_ALLOWED_CREDENTIAL_OFFER_HOSTS', 'issuer.example.com')
-    const parsed = parseCredentialOfferInput('https://issuer.example.com/not-an-offer-path')
+    const parsed = parseCredentialOfferInput(
+      'https://issuer.example.com/not-an-offer-path'
+    )
     expect(parsed).not.toBeNull()
   })
 
@@ -156,7 +158,9 @@ describe('parseCredentialOfferInput', () => {
   })
 
   it('rejects unsupported URL schemes', () => {
-    expect(parseCredentialOfferInput('ftp://issuer.example.com/credential-offer/1')).toBeNull()
+    expect(
+      parseCredentialOfferInput('ftp://issuer.example.com/credential-offer/1')
+    ).toBeNull()
   })
 
   it('rejects credential_offer payload with invalid credential_issuer URL', () => {

--- a/src/utils/tests/env.test.ts
+++ b/src/utils/tests/env.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getApiBaseUrl } from '../env'
+
+describe('getApiBaseUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('defaults to localhost api path when env is missing', () => {
+    vi.stubEnv('VITE_API_BASE_URL', undefined)
+    expect(getApiBaseUrl()).toBe('http://localhost:3000/api/v1')
+  })
+
+  it('normalizes trailing slash and appends /api/v1', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com/')
+    expect(getApiBaseUrl()).toBe('https://api.example.com/api/v1')
+  })
+
+  it('does not append /api/v1 when already provided', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com/api/v1')
+    expect(getApiBaseUrl()).toBe('https://api.example.com/api/v1')
+  })
+})

--- a/src/utils/tests/issuanceErrors.test.ts
+++ b/src/utils/tests/issuanceErrors.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { ApiError } from '../../api/client'
+import { IssuanceError } from '../../api/issuance'
+import { issuanceUserMessage, toIssuanceApiError } from '../issuanceErrors'
+
+describe('toIssuanceApiError', () => {
+  it('maps IssuanceError instances without losing fields', () => {
+    const error = new IssuanceError({
+      httpStatus: 401,
+      error: 'unauthorized',
+      error_description: 'Token expired',
+    })
+
+    expect(toIssuanceApiError(error)).toEqual({
+      httpStatus: 401,
+      error: 'unauthorized',
+      error_description: 'Token expired',
+    })
+  })
+
+  it('maps ApiError instances into issuance-compatible errors', () => {
+    const error = new ApiError(500, 'Boom', {
+      errorCode: 'internal_error',
+      errorDescription: 'Unexpected backend failure',
+    })
+
+    expect(toIssuanceApiError(error)).toEqual({
+      httpStatus: 500,
+      error: 'internal_error',
+      error_description: 'Unexpected backend failure',
+    })
+  })
+
+  it('maps ApiError with null errorCode to internal_error fallback', () => {
+    const error = new ApiError(400, 'Bad request', {
+      errorCode: null,
+      errorDescription: null,
+    })
+
+    expect(toIssuanceApiError(error)).toEqual({
+      httpStatus: 400,
+      error: 'internal_error',
+      error_description: null,
+    })
+  })
+
+  it('falls back to internal_error for unknown error types', () => {
+    expect(toIssuanceApiError('badness')).toEqual({
+      httpStatus: 0,
+      error: 'internal_error',
+      error_description: null,
+    })
+  })
+})
+
+describe('issuanceUserMessage', () => {
+  it('prefers error_description when present', () => {
+    expect(
+      issuanceUserMessage({
+        httpStatus: 400,
+        error: 'invalid_request',
+        error_description: 'Readable message from server',
+      })
+    ).toBe('Readable message from server')
+  })
+
+  it('returns mapped message for known issuance codes', () => {
+    expect(
+      issuanceUserMessage({
+        httpStatus: 400,
+        error: 'invalid_credential_offer',
+        error_description: null,
+      })
+    ).toContain('valid credential offer')
+  })
+
+  it.each([
+    ['unauthorized', 'Authentication failed.'],
+    ['issuer_metadata_fetch_failed', 'Could not reach the credential issuer.'],
+    [
+      'auth_server_metadata_fetch_failed',
+      'Could not reach the authorization server.',
+    ],
+    ['invalid_tx_code', 'transaction code is invalid'],
+    ['session_not_found', 'issuance session expired'],
+    ['invalid_session_state', 'issuance step is no longer valid'],
+    ['invalid_request', 'request could not be processed'],
+    ['internal_error', 'unexpected server error'],
+  ] as const)('maps %s to a friendly message', (error, expectedSnippet) => {
+    expect(
+      issuanceUserMessage({
+        httpStatus: 400,
+        error,
+        error_description: null,
+      })
+    ).toContain(expectedSnippet)
+  })
+
+  it('returns 5xx default for unknown codes', () => {
+    expect(
+      issuanceUserMessage({
+        httpStatus: 503,
+        error: 'access_denied',
+        error_description: null,
+      })
+    ).toContain('server encountered an error')
+  })
+
+  it('returns non-5xx default for unknown codes', () => {
+    expect(
+      issuanceUserMessage({
+        httpStatus: 400,
+        error: 'access_denied',
+        error_description: null,
+      })
+    ).toContain('could not be completed')
+  })
+})

--- a/src/utils/tests/issuanceErrors.test.ts
+++ b/src/utils/tests/issuanceErrors.test.ts
@@ -77,10 +77,7 @@ describe('issuanceUserMessage', () => {
   it.each([
     ['unauthorized', 'Authentication failed.'],
     ['issuer_metadata_fetch_failed', 'Could not reach the credential issuer.'],
-    [
-      'auth_server_metadata_fetch_failed',
-      'Could not reach the authorization server.',
-    ],
+    ['auth_server_metadata_fetch_failed', 'Could not reach the authorization server.'],
     ['invalid_tx_code', 'transaction code is invalid'],
     ['session_not_found', 'issuance session expired'],
     ['invalid_session_state', 'issuance step is no longer valid'],


### PR DESCRIPTION


## Summary
This PR improves overall test coverage in `cloud-wallet-ui` by adding and expanding unit/component tests across key user flows and utility logic.

### What was added/updated
- Added/expanded tests for:
  - API validation and client behavior
  - Registration and credential-related pages
  - Issuance flow components (including tx-code and error-card behavior)
  - PWA hook behavior
  - Route constants and utility helpers (`credentialOffer`, `credentialDisplay`, `issuanceErrors`, `env`)
  - Issuance state context behavior

### Why
- To increase confidence in critical wallet flows
- To reduce untested branches in error-handling and edge-case paths
- To improve regression safety for future changes

## Test Plan
- [x] Run unit tests:
  - `npm test`
- [x] Run coverage:
  - `npm test -- --coverage`
- [x] Verify all test files pass locally

## Coverage Note
Some remaining uncovered lines are defensive/fallback paths that are not realistically triggered via normal UI flow tests:

- `TxCodeInput.tsx` line `45`
- `CredentialTypeDetailsPage.tsx` lines `152`, `422-428`
- `RegistrationPage.tsx` line `19`
- `credentialOffer.ts` line `105`

These are guard branches that remain intentionally defensive in the code implementation

Closes https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/26

<img width="1125" height="873" alt="image" src="https://github.com/user-attachments/assets/9ba661d9-af9d-48dd-95da-0b4bf4547688" />
