### PR TITLE
Align user decline with POST /consent `accepted: false` 

### DIFF
--- a/src/pages/CredentialTypeDetailsPage.tsx
+++ b/src/pages/CredentialTypeDetailsPage.tsx
@@ -76,7 +76,7 @@ function stepLabel(step: ProcessingStep): string {
 
 type OverlayStatus =
   | { kind: 'hidden' }
-  | { kind: 'submitting' }
+  | { kind: 'submitting'; consentIntent: 'accept' | 'reject' }
   | { kind: 'awaiting_tx_code'; txCodeSpec: TxCodeSpec }
   | { kind: 'submitting_tx_code'; txCodeSpec: TxCodeSpec }
   | { kind: 'tx_code_error'; txCodeSpec: TxCodeSpec; errorMessage: string }
@@ -117,7 +117,9 @@ function ProcessingOverlay({
   const isError = false
   const message =
     status.kind === 'submitting'
-      ? 'Submitting consent…'
+      ? status.consentIntent === 'reject'
+        ? 'Declining offer…'
+        : 'Submitting consent…'
       : status.kind === 'processing'
         ? stepLabel(status.step)
         : ''
@@ -202,7 +204,8 @@ export function CredentialTypeDetailsPage() {
 
   const [overlay, setOverlay] = useState<OverlayStatus>({ kind: 'hidden' })
   const [isCancelling, setIsCancelling] = useState(false)
-  const issueInFlightRef = useRef(false)
+  /** Guards POST /consent for both accept (Issue VC) and reject flows. */
+  const consentInFlightRef = useRef(false)
   const txCodeSubmitInFlightRef = useRef(false)
   const txCodeCancelInFlightRef = useRef(false)
 
@@ -296,9 +299,9 @@ export function CredentialTypeDetailsPage() {
   const displayRows = buildDisplayRows(selectedType)
 
   const handleIssueVc = async () => {
-    if (issueInFlightRef.current || isCancelling) return
-    issueInFlightRef.current = true
-    setOverlay({ kind: 'submitting' })
+    if (consentInFlightRef.current || isCancelling) return
+    consentInFlightRef.current = true
+    setOverlay({ kind: 'submitting', consentIntent: 'accept' })
 
     let consentResponse: ConsentResponse
     try {
@@ -318,15 +321,22 @@ export function CredentialTypeDetailsPage() {
         canRetry: true,
         retryAction: 'issue_vc',
       })
-      issueInFlightRef.current = false
+      consentInFlightRef.current = false
       return
     }
 
-    openStream(session.session_id)
-
     try {
       switch (consentResponse.next_action) {
+        case 'rejected':
+          // Defensive: accepting a subset should not yield rejected; if it does, treat like decline.
+          closeStream()
+          offerState.clear()
+          setOverlay({ kind: 'hidden' })
+          navigate(routes.scan, { replace: true })
+          break
+
         case 'redirect':
+          openStream(session.session_id)
           if (consentResponse.authorization_url) {
             doAuthRedirect(consentResponse.authorization_url)
             setOverlay({ kind: 'processing', step: 'authorization' })
@@ -347,6 +357,7 @@ export function CredentialTypeDetailsPage() {
           break
 
         case 'provide_tx_code': {
+          openStream(session.session_id)
           const txSpec = session.tx_code
           if (!txSpec) {
             const apiError: IssuanceApiError = {
@@ -369,17 +380,68 @@ export function CredentialTypeDetailsPage() {
         }
 
         case 'none':
+          openStream(session.session_id)
           setOverlay({ kind: 'processing', step: '' })
-          break
-
-        case 'rejected':
-          setOverlay({ kind: 'hidden' })
-          closeStream()
-          navigate(routes.scan, { replace: true })
           break
       }
     } finally {
-      issueInFlightRef.current = false
+      consentInFlightRef.current = false
+    }
+  }
+
+  /**
+   * User explicitly declines the credential offer (spec: POST …/consent with accepted=false).
+   * This is distinct from operational {@link handleCancel} / {@link cancelSession}, which aborts
+   * an in-flight issuance after consent has already been accepted.
+   */
+  const handleReject = async () => {
+    if (consentInFlightRef.current || isCancelling) return
+    consentInFlightRef.current = true
+    closeStream()
+    setOverlay({ kind: 'submitting', consentIntent: 'reject' })
+
+    let consentResponse: ConsentResponse
+    try {
+      consentResponse = await submitConsent(session.session_id, false, [])
+    } catch (err) {
+      const apiError = toIssuanceApiError(err)
+      const message =
+        apiError.httpStatus === 0 && err instanceof Error
+          ? err.message
+          : issuanceUserMessage(apiError)
+      setOverlay({
+        kind: 'failed',
+        apiError,
+        message,
+        canRetry: false,
+        retryAction: null,
+      })
+      consentInFlightRef.current = false
+      return
+    }
+
+    try {
+      if (consentResponse.next_action === 'rejected') {
+        offerState.clear()
+        setOverlay({ kind: 'hidden' })
+        navigate(routes.scan, { replace: true })
+        return
+      }
+      const apiError: IssuanceApiError = {
+        httpStatus: 0,
+        error: 'invalid_request',
+        error_description:
+          'The server returned an unexpected response after declining the offer. Please try again.',
+      }
+      setOverlay({
+        kind: 'failed',
+        apiError,
+        message: issuanceUserMessage(apiError),
+        canRetry: false,
+        retryAction: null,
+      })
+    } finally {
+      consentInFlightRef.current = false
     }
   }
 
@@ -552,14 +614,29 @@ export function CredentialTypeDetailsPage() {
             Issue VC
           </button>
 
-          <button
-            type="button"
-            onClick={() => void handleCancel()}
-            disabled={isCancelling}
-            className="mt-1 h-9 w-full rounded-[4px] border border-slate-400 bg-transparent text-[16px] font-normal text-slate-900 transition-colors duration-150 hover:bg-slate-100 active:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isCancelling ? 'Cancelling…' : 'Cancel'}
-          </button>
+          {overlay.kind === 'hidden' ? (
+            <button
+              type="button"
+              onClick={() => void handleReject()}
+              disabled={isCancelling}
+              className="mt-1 h-9 w-full rounded-[4px] border border-slate-400 bg-transparent text-[16px] font-normal text-slate-900 transition-colors duration-150 hover:bg-slate-100 active:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Reject
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void handleCancel()}
+              disabled={
+                isCancelling ||
+                overlay.kind === 'submitting' ||
+                overlay.kind === 'submitting_tx_code'
+              }
+              className="mt-1 h-9 w-full rounded-[4px] border border-slate-400 bg-transparent text-[16px] font-normal text-slate-900 transition-colors duration-150 hover:bg-slate-100 active:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isCancelling ? 'Cancelling…' : 'Cancel'}
+            </button>
+          )}
         </div>
       </div>
     </PageContainer>

--- a/src/pages/tests/CredentialTypeDetailsPage.test.tsx
+++ b/src/pages/tests/CredentialTypeDetailsPage.test.tsx
@@ -140,10 +140,10 @@ describe('CredentialTypeDetailsPage', () => {
     expect(screen.getByText('Logo Alt Text')).toBeTruthy()
   })
 
-  it('renders Issue VC and Cancel buttons', () => {
+  it('renders Issue VC and Reject buttons on the consent screen', () => {
     renderPage()
     expect(screen.getByRole('button', { name: 'Issue VC' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeTruthy()
   })
 
   it('does NOT render claims from a non-spec extension field', () => {
@@ -296,14 +296,23 @@ describe('CredentialTypeDetailsPage', () => {
     })
   })
 
-  it('calls cancelSession and navigates to credential types on Cancel click', async () => {
-    mockCancelSession.mockResolvedValueOnce(undefined)
+  it('calls POST /consent with accepted=false on Reject without cancelSession or SSE', async () => {
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'rejected',
+    } as ConsentResponse)
 
     const user = userEvent.setup()
     renderPage()
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Reject' }))
 
-    expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes)
+    await waitFor(() => {
+      expect(mockSubmitConsent).toHaveBeenCalledWith('ses_123', false, [])
+    })
+    expect(mockCancelSession).not.toHaveBeenCalled()
+    expect(mockOpenStream).not.toHaveBeenCalled()
+    expect(mockOfferState.clear).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith(routes.scan, { replace: true })
   })
 
   it('calls cancelSession when cancelling from TX code screen', async () => {
@@ -514,7 +523,7 @@ describe('CredentialTypeDetailsPage', () => {
     })
   })
 
-  it('navigates to scan when consent result is rejected', async () => {
+  it('navigates to scan when user rejects via Reject button', async () => {
     mockSubmitConsent.mockResolvedValueOnce({
       session_id: 'ses_123',
       next_action: 'rejected',
@@ -522,7 +531,7 @@ describe('CredentialTypeDetailsPage', () => {
 
     const user = userEvent.setup()
     renderPage()
-    await user.click(screen.getByRole('button', { name: 'Issue VC' }))
+    await user.click(screen.getByRole('button', { name: 'Reject' }))
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(routes.scan, { replace: true })
@@ -726,12 +735,55 @@ describe('CredentialTypeDetailsPage', () => {
     expect(mockCancelSession).toHaveBeenCalledTimes(1)
   })
 
-  it('does not call cancelSession when cancelling from hidden overlay state', async () => {
+  it('shows declining overlay while reject consent is in flight', async () => {
+    mockSubmitConsent.mockReturnValue(
+      new Promise<ConsentResponse>(() => {
+        /* unresolved */
+      })
+    )
+
     const user = userEvent.setup()
     renderPage()
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-    expect(mockCancelSession).not.toHaveBeenCalled()
-    expect(mockNavigate).toHaveBeenCalledWith(routes.credentialTypes)
+    await user.click(screen.getByRole('button', { name: 'Reject' }))
+
+    expect(screen.getByText('Declining offer…')).toBeTruthy()
+  })
+
+  it('shows error when reject consent returns unexpected next_action', async () => {
+    mockSubmitConsent.mockResolvedValueOnce({
+      session_id: 'ses_123',
+      next_action: 'none',
+    } as ConsentResponse)
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Reject' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /The server returned an unexpected response after declining the offer/i
+        )
+      ).toBeTruthy()
+    })
+    expect(mockOpenStream).not.toHaveBeenCalled()
+    expect(mockOfferState.clear).not.toHaveBeenCalled()
+  })
+
+  it('prevents duplicate Reject clicks while consent is in flight', async () => {
+    mockSubmitConsent.mockReturnValue(
+      new Promise<ConsentResponse>(() => {
+        /* unresolved */
+      })
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    const rejectButton = screen.getByRole('button', { name: 'Reject' })
+    await user.click(rejectButton)
+    await user.click(rejectButton)
+
+    expect(mockSubmitConsent).toHaveBeenCalledTimes(1)
   })
 
   it('restarts flow from failure overlay scan-again action', async () => {


### PR DESCRIPTION


Declining the credential offer now uses **`POST /issuance/{session_id}/consent`** with **`accepted: false`** and an empty selection, per OID4VCI-style contract. **`POST …/cancel`** is kept only for operational abort after the flow has started (processing, tx-code, failure overlay).

### Changes

- **Reject** on the idle credential-details screen → `submitConsent(sessionId, false, [])`; on `next_action: rejected`, clear issuance state and return to **scan** (no SSE, no cancel).
- **Cancel** when overlay is active → existing `cancelSession` behavior; **Issue VC** unchanged for accept + subset selection.
- **SSE** opened only for `redirect` / `provide_tx_code` / `none` after accept consent (not for terminal reject).
- Submitting overlay distinguishes **“Declining offer…”** vs **“Submitting consent…”**.
- Tests cover reject API args, no cancel/SSE on reject, navigation, declining UX, unexpected consent response, and duplicate-click guard.

### Files

- `src/pages/CredentialTypeDetailsPage.tsx`
- `src/pages/tests/CredentialTypeDetailsPage.test.tsx`


Closes https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/29

