### PR TITLE
Implement getCredentials function with optional query parameters and add tests for various filters

### DIFF
--- a/src/api/credentials.ts
+++ b/src/api/credentials.ts
@@ -1,6 +1,70 @@
 import { apiGet } from './client'
-import type { CredentialListResponse, CredentialRecord } from '../types/credential'
+import type {
+  CredentialListResponse,
+  CredentialRecord,
+  CredentialStatus,
+  CredentialFormat,
+} from '../types/credential'
 import { validateCredentialListResponse, validateCredentialRecord } from './validation'
+
+/**
+ * Optional query-parameter filters for `getCredentials()`.
+ *
+ * All fields are optional. Omitted or `undefined` fields produce no query
+ * parameter. Empty arrays are treated as omitted.
+ *
+ * Spec: GET /credentials (openapi/openapi.yaml lines 611-659)
+ *
+ * @example
+ * // Only active PID credentials from a specific issuer
+ * getCredentials({
+ *   status: 'active',
+ *   credential_types: ['eu.europa.ec.eudi.pid.1'],
+ *   issuer: 'https://issuer.example.eu',
+ * })
+ */
+export type CredentialFilters = {
+  /**
+   * Filter by one or more credential configuration IDs.
+   * Repeated as individual `credential_types` query params per the spec.
+   */
+  credential_types?: string[]
+  /** Filter by credential validity status. */
+  status?: CredentialStatus
+  /** Filter by credential format. */
+  format?: CredentialFormat
+  /** Filter by issuer identifier URI. */
+  issuer?: string
+}
+
+/**
+ * Build a query string from the supplied filters.
+ * Returns an empty string when no filters are active.
+ */
+function buildQueryString(filters: CredentialFilters): string {
+  const params = new URLSearchParams()
+
+  if (filters.credential_types && filters.credential_types.length > 0) {
+    for (const type of filters.credential_types) {
+      params.append('credential_types', type)
+    }
+  }
+
+  if (filters.status !== undefined) {
+    params.set('status', filters.status)
+  }
+
+  if (filters.format !== undefined) {
+    params.set('format', filters.format)
+  }
+
+  if (filters.issuer !== undefined) {
+    params.set('issuer', filters.issuer)
+  }
+
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
 
 /**
  * Fetch all credentials for the authenticated tenant.
@@ -8,10 +72,17 @@ import { validateCredentialListResponse, validateCredentialRecord } from './vali
  * Spec: GET /credentials
  * Response: CredentialListResponse (200) → { credentials: CredentialRecord[] }
  *
+ * @param filters - Optional query-parameter filters. All fields are optional;
+ *                  omitting the argument (or passing `{}`) fetches all
+ *                  credentials without filtering.
+ *
  * The response is validated against the OpenAPI contract before being returned.
  */
-export async function getCredentials(): Promise<CredentialListResponse> {
-  const raw = await apiGet<unknown>('/credentials')
+export async function getCredentials(
+  filters: CredentialFilters = {}
+): Promise<CredentialListResponse> {
+  const qs = buildQueryString(filters)
+  const raw = await apiGet<unknown>(`/credentials${qs}`)
   return validateCredentialListResponse(raw)
 }
 

--- a/src/api/tests/credentials.test.ts
+++ b/src/api/tests/credentials.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getCredentials } from '../credentials'
+import { ApiError } from '../client'
+vi.mock('../../auth/authService', () => ({
+  getBearerToken: vi.fn(async () => 'mock.jwt.token'),
+}))
+
+const validCredential = {
+  id: 'c3d4e5f6-7890-abcd-ef12-3456789abcde',
+  credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
+  format: 'dc+sd-jwt',
+  issuer: 'https://issuer.example.eu',
+  status: 'active',
+  issued_at: '2026-04-08T14:35:00Z',
+  expires_at: '2027-04-08T14:35:00Z',
+  claims: { given_name: 'Jane', family_name: 'Doe' },
+}
+
+const validListResponse = { credentials: [validCredential] }
+const emptyListResponse = { credentials: [] }
+
+type MockResponse = {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+
+function makeResponse(
+  partial: Partial<MockResponse> & Pick<MockResponse, 'ok' | 'status'>
+): MockResponse {
+  return {
+    ok: partial.ok,
+    status: partial.status,
+    json: partial.json ?? (async () => ({})),
+  }
+}
+
+/** Extract the URL that was passed to fetch in the Nth call (0-indexed). */
+function calledUrl(fetchMock: ReturnType<typeof vi.fn>, callIndex = 0): string {
+  return (fetchMock.mock.calls[callIndex] as [string, unknown])[0]
+}
+
+describe('getCredentials — no filters', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://api.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('calls GET /credentials with no query string when called without arguments', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(calledUrl(fetchMock)).toBe('http://api.test/api/v1/credentials')
+  })
+
+  it('calls GET /credentials with no query string when called with an empty filters object', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({})
+
+    expect(calledUrl(fetchMock)).toBe('http://api.test/api/v1/credentials')
+  })
+
+  it('returns validated credential list on success', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await getCredentials()
+
+    expect(result.credentials).toHaveLength(1)
+    expect(result.credentials[0].id).toBe('c3d4e5f6-7890-abcd-ef12-3456789abcde')
+  })
+
+  it('returns empty credentials list when server responds with empty array', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => emptyListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await getCredentials()
+
+    expect(result.credentials).toEqual([])
+  })
+
+  it('throws ApiError on non-2xx response', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'unauthorized', error_description: 'Bad token' }),
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getCredentials()).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('getCredentials — status filter', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://api.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('appends status=active to the URL', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({ status: 'active' })
+
+    expect(calledUrl(fetchMock)).toBe('http://api.test/api/v1/credentials?status=active')
+  })
+
+  it('appends status=expired to the URL', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => emptyListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({ status: 'expired' })
+
+    expect(calledUrl(fetchMock)).toBe('http://api.test/api/v1/credentials?status=expired')
+  })
+})
+
+describe('getCredentials — format filter', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://api.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('appends format=dc%2Bsd-jwt to the URL (URL-encoded)', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({ format: 'dc+sd-jwt' })
+
+    const url = calledUrl(fetchMock)
+    expect(url).toContain('format=dc%2Bsd-jwt')
+  })
+})
+
+describe('getCredentials — issuer filter', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://api.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('URL-encodes the issuer URI', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({ issuer: 'https://issuer.example.eu' })
+
+    const url = calledUrl(fetchMock)
+    expect(url).toContain(`issuer=${encodeURIComponent('https://issuer.example.eu')}`)
+  })
+})
+
+describe('getCredentials — credential_types filter', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://api.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('appends a single credential_types param', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({ credential_types: ['eu.europa.ec.eudi.pid.1'] })
+
+    const url = calledUrl(fetchMock)
+    expect(url).toContain('credential_types=eu.europa.ec.eudi.pid.1')
+    // Only one occurrence
+    expect(url.split('credential_types=').length - 1).toBe(1)
+  })
+
+  it('appends multiple credential_types as repeated params', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({
+      credential_types: ['eu.europa.ec.eudi.pid.1', 'eu.europa.ec.eudi.lpid.1'],
+    })
+
+    const url = calledUrl(fetchMock)
+    expect(url).toContain('credential_types=eu.europa.ec.eudi.pid.1')
+    expect(url).toContain('credential_types=eu.europa.ec.eudi.lpid.1')
+    expect(url.split('credential_types=').length - 1).toBe(2)
+  })
+
+  it('omits credential_types param when array is empty', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => emptyListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({ credential_types: [] })
+
+    expect(calledUrl(fetchMock)).toBe('http://api.test/api/v1/credentials')
+  })
+})
+
+describe('getCredentials — combined filters', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://api.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('combines all four filter types into a single query string', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({
+      credential_types: ['eu.europa.ec.eudi.pid.1'],
+      status: 'active',
+      format: 'dc+sd-jwt',
+      issuer: 'https://issuer.example.eu',
+    })
+
+    const url = calledUrl(fetchMock)
+    expect(url).toContain('credential_types=eu.europa.ec.eudi.pid.1')
+    expect(url).toContain('status=active')
+    expect(url).toContain('format=dc%2Bsd-jwt')
+    expect(url).toContain(`issuer=${encodeURIComponent('https://issuer.example.eu')}`)
+  })
+
+  it('omits undefined filter fields from the query string', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, status: 200, json: async () => validListResponse })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCredentials({ status: 'active' })
+
+    const url = calledUrl(fetchMock)
+    expect(url).not.toContain('credential_types')
+    expect(url).not.toContain('format')
+    expect(url).not.toContain('issuer')
+  })
+})


### PR DESCRIPTION
The OpenAPI specification defines optional query parameters for filtering credentials (`credential_types`, `status`, `format`, `issuer`), but the current [`getCredentials()`](src/api/credentials.ts:13) function does not support these filters. The frontend may need these filters for improved UX (e.g., filtering by status or credential type).

### OpenAPI Spec Reference
Lines 611-659 in [`openapi/openapi.yaml`](openapi/openapi.yaml:611)

### Current Implementation
```typescript
// src/api/credentials.ts - No filter support
export async function getCredentials(): Promise<CredentialListResponse> {
  const raw = await apiGet<unknown>('/credentials')
  return validateCredentialListResponse(raw)
}
```

### Tasks
- [x] Add optional `filters` parameter to `getCredentials()` function
- [x] Support query parameters: `credential_types`, `status`, `format`, `issuer`
- [x] Update URL construction to include query string when filters are provided
- [x] Add URL encoding for query parameter values
- [x] Update TypeScript types to include filter interface
- [x] Add unit tests for filter functionality
- [x] Update JSDoc comments to document filter usage