### PR TITLE
Update credential format from 'vc+sd-jwt' to 'dc+sd-jwt' across multiple test files

### DIFF
--- a/src/api/tests/issuance.test.ts
+++ b/src/api/tests/issuance.test.ts
@@ -56,7 +56,7 @@ const minimalSession: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'vc+sd-jwt',
+      format: 'dc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',

--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -19,7 +19,7 @@ const validStartIssuanceResponse: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'vc+sd-jwt',
+      format: 'dc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',
@@ -114,7 +114,7 @@ describe('validateStartIssuanceResponse', () => {
       credential_types: [
         {
           credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { description: 'no name here' },
         },
       ],

--- a/src/hooks/test/useIssuanceSession.test.ts
+++ b/src/hooks/test/useIssuanceSession.test.ts
@@ -18,7 +18,7 @@ const minimalSession: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'vc+sd-jwt',
+      format: 'dc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',

--- a/src/pages/tests/CredentialTypeDetailsPage.test.tsx
+++ b/src/pages/tests/CredentialTypeDetailsPage.test.tsx
@@ -68,7 +68,7 @@ function buildOffer(
     credential_types: [
       {
         credential_configuration_id: 'identity_credential',
-        format: 'vc+sd-jwt',
+        format: 'dc+sd-jwt',
         display: {
           name: 'Identity Credential',
           description: 'Official identity document',
@@ -1024,7 +1024,7 @@ describe('CredentialTypeDetailsPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'identity_credential',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { name: 'Identity Credential' },
         },
       ],

--- a/src/pages/tests/CredentialTypesPage.test.tsx
+++ b/src/pages/tests/CredentialTypesPage.test.tsx
@@ -42,12 +42,12 @@ function baseOffer(
     credential_types: [
       {
         credential_configuration_id: 'pid',
-        format: 'vc+sd-jwt',
+        format: 'dc+sd-jwt',
         display: { name: 'Personal ID' },
       },
       {
         credential_configuration_id: 'address',
-        format: 'vc+sd-jwt',
+        format: 'dc+sd-jwt',
         display: { name: 'Address Credential' },
       },
     ],
@@ -145,7 +145,7 @@ describe('CredentialTypesPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'a',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { name: 'Type A' },
         },
       ],
@@ -165,7 +165,7 @@ describe('CredentialTypesPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'pid',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { name: 'Personal ID' },
         },
       ],


### PR DESCRIPTION
This PR updates all files to use the credential format dc+sd-jwt in most test files instead of vc+sd-jwt, which wasn't in alignment with the OID4VCI final spec. 

Closes: #39 