### PR TITLE
Refactor logo validation to require alt_text and update related test and components

### DIFF
--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -182,7 +182,7 @@ describe('validateStartIssuanceResponse', () => {
     expect(() => validateStartIssuanceResponse(input)).not.toThrow()
   })
 
-  it('accepts display.logo object without alt_text', () => {
+  it('throws ContractError when display.logo object omits alt_text', () => {
     const input = {
       ...validStartIssuanceResponse,
       credential_types: [
@@ -195,7 +195,7 @@ describe('validateStartIssuanceResponse', () => {
         },
       ],
     }
-    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+    expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
   })
 
   it('accepts display.logo object with alt_text', () => {

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -132,10 +132,7 @@ function validateCredentialDisplay(raw: unknown): CredentialDisplay {
     const logoObj = requireObject(ctx, 'logo', obj.logo)
     logo = {
       uri: requireString(ctx, 'logo.uri', logoObj.uri),
-      alt_text:
-        logoObj.alt_text !== undefined
-          ? requireString(ctx, 'logo.alt_text', logoObj.alt_text)
-          : undefined,
+      alt_text: requireString(ctx, 'logo.alt_text', logoObj.alt_text),
     }
   } else if (obj.logo === null) {
     logo = null

--- a/src/components/issuance/CredentailOfferCard.tsx
+++ b/src/components/issuance/CredentailOfferCard.tsx
@@ -63,7 +63,7 @@ function CredentialTypePill({
         {logo?.uri && !imgFailed && (
           <img
             src={logo.uri}
-            alt={logo.alt_text ?? `${name} logo`}
+            alt={logo.alt_text}
             className="h-6 w-6 shrink-0 rounded object-contain bg-white/20"
             onError={() => setImgFailed(true)}
           />

--- a/src/pages/CredentialTypeDetailsPage.tsx
+++ b/src/pages/CredentialTypeDetailsPage.tsx
@@ -50,7 +50,7 @@ function buildDisplayRows(
   if (credType.display.logo?.uri) {
     rows.push({ label: 'Logo URI', value: credType.display.logo.uri })
   }
-  if (credType.display.logo?.alt_text) {
+  if (credType.display.logo) {
     rows.push({ label: 'Logo Alt Text', value: credType.display.logo.alt_text })
   }
 

--- a/src/types/issuance.ts
+++ b/src/types/issuance.ts
@@ -6,7 +6,7 @@ export type IssuerSummary = {
 
 export type CredentialLogo = {
   uri: string
-  alt_text?: string
+  alt_text: string
 }
 
 export type CredentialDisplay = {


### PR DESCRIPTION
The OpenAPI specification defines `alt_text` as a required field in the [`CredentialLogo`](openapi/openapi.yaml:1048) schema, but the current TypeScript type and validation treat it as optional. This could lead to missing accessibility text in the UI.

### OpenAPI Spec Reference
Lines 1048-1062 in [`openapi/openapi.yaml`](openapi/openapi.yaml:1048)

```yaml
CredentialLogo:
  type: object
  required:
    - uri
    - alt_text    # ← Required per spec
```

### Current Implementation
In [`src/types/issuance.ts`](src/types/issuance.ts:7):
```typescript
export type CredentialLogo = {
  uri: string
  alt_text?: string  // ← Should be required
}
```

In [`src/api/validation.ts`](src/api/validation.ts:127):
```typescript
alt_text:
  logoObj.alt_text !== undefined
    ? requireString(ctx, 'logo.alt_text', logoObj.alt_text)
    : undefined,  // ← Should validate as required
```

### Tasks
- [x] Update `CredentialLogo` type to make `alt_text` required
- [x] Update `validateCredentialDisplay()` to require `alt_text` when logo is present
- [x] Update all test fixtures to include `alt_text` in logo objects
- [x] Update UI components to handle required `alt_text` properly
- [x] Verify no runtime errors after making field required


Closes: #41 