### PR TITLE
test(e2e): comprehensive issuance flow tests with mocked API (#47)

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,0 +1,4 @@
+# Production build used by Playwright (`npm run build:e2e`).
+# Same-origin `/api/v1` is fulfilled by Playwright network mocks (see e2e/fixtures/api-mock.ts).
+VITE_API_BASE_URL=
+VITE_E2E=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,26 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/e2e/fixtures/api-mock.ts
+++ b/e2e/fixtures/api-mock.ts
@@ -1,8 +1,6 @@
 import type { Page } from '@playwright/test'
 
-import {
-  E2E_CREDENTIAL_CONFIGURATION_ID,
-} from '../../src/e2e/scan-sample-offer'
+import { E2E_CREDENTIAL_CONFIGURATION_ID } from '../../src/e2e/scan-sample-offer'
 
 /** Must match `session_id` returned from mocked `POST /issuance/start`. */
 export const E2E_SESSION_ID = 'ses_e2e_playwright_session'

--- a/e2e/fixtures/api-mock.ts
+++ b/e2e/fixtures/api-mock.ts
@@ -1,0 +1,300 @@
+import type { Page } from '@playwright/test'
+
+import {
+  E2E_CREDENTIAL_CONFIGURATION_ID,
+} from '../../src/e2e/scan-sample-offer'
+
+/** Must match `session_id` returned from mocked `POST /issuance/start`. */
+export const E2E_SESSION_ID = 'ses_e2e_playwright_session'
+
+/** Credential id returned in mocked SSE `completed` and `GET /credentials/:id`. */
+export const E2E_ISSUED_CREDENTIAL_ID = 'cccccccc-cccc-4ccc-cccc-cccccccccccc'
+
+const MOCK_AUTH_BASE = 'https://mock-authorize.e2e.test'
+
+export type IssuanceStartProfile = 'auth_code' | 'pre_no_tx' | 'pre_tx'
+
+export type InstallApiMockOptions = {
+  startProfile: IssuanceStartProfile
+  /** Simulated `POST /issuance/start` failures (after QR payload parses). */
+  startFailure?: 'invalid_offer' | 'network'
+}
+
+function buildStartIssuanceBody(profile: IssuanceStartProfile) {
+  const base = {
+    session_id: E2E_SESSION_ID,
+    expires_at: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+    issuer: {
+      credential_issuer: 'https://issuer.e2e.test',
+      display_name: 'E2E Issuer',
+      logo_uri: null,
+    },
+    credential_types: [
+      {
+        credential_configuration_id: E2E_CREDENTIAL_CONFIGURATION_ID,
+        format: 'dc+sd-jwt',
+        display: {
+          name: 'E2E PID',
+          description: 'Playwright fixture credential',
+          background_color: '#12107c',
+          text_color: '#ffffff',
+          logo: null,
+        },
+      },
+    ],
+  }
+
+  if (profile === 'auth_code') {
+    return {
+      ...base,
+      flow: 'authorization_code',
+      tx_code_required: false,
+      tx_code: null,
+    }
+  }
+
+  if (profile === 'pre_tx') {
+    return {
+      ...base,
+      flow: 'pre_authorized_code',
+      tx_code_required: true,
+      tx_code: {
+        input_mode: 'numeric',
+        length: 6,
+        description: 'Enter the 6-digit code from the mock issuer.',
+      },
+    }
+  }
+
+  return {
+    ...base,
+    flow: 'pre_authorized_code',
+    tx_code_required: false,
+    tx_code: null,
+  }
+}
+
+/**
+ * Intercepts same-origin `/api/v1/**` and the fake authorization-server origin used
+ * in the authorization-code scenario. Keeps tests deterministic without a real backend.
+ */
+function sseProcessingFrame(sessionId: string) {
+  return `event: processing\ndata: ${JSON.stringify({
+    session_id: sessionId,
+    state: 'processing',
+    step: 'requesting_credential',
+  })}\n\n`
+}
+
+function sseCompletedFrame(sessionId: string) {
+  return `event: completed\ndata: ${JSON.stringify({
+    session_id: sessionId,
+    state: 'completed',
+    credential_ids: [E2E_ISSUED_CREDENTIAL_ID],
+    credential_types: [E2E_CREDENTIAL_CONFIGURATION_ID],
+  })}\n\n`
+}
+
+export async function installIssuanceApiMock(
+  page: Page,
+  options: InstallApiMockOptions
+): Promise<void> {
+  /**
+   * For `pre_tx`, `GET /events` must not send `completed` before the user submits the TX code.
+   * Playwright `route.fulfill` only accepts string/Buffer bodies (no live streams), so we block
+   * the SSE route until `POST .../tx-code` resolves with the full SSE payload.
+   */
+  let resolvePreTxSseBody: ((body: string) => void) | null = null
+
+  await page.route(`${MOCK_AUTH_BASE}/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: '<!doctype html><html lang="en"><head><title>E2E mock AS</title></head><body><p>Mock authorization server (Playwright)</p></body></html>',
+    })
+  })
+
+  await page.route('**/api/v1/**', async (route) => {
+    const req = route.request()
+    const url = new URL(req.url())
+    const path = url.pathname
+    const method = req.method()
+
+    if (method === 'POST' && path === '/api/v1/tenants') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          tenant_id: 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb',
+          name: 'E2E Tenant',
+        }),
+      })
+      return
+    }
+
+    if (method === 'POST' && path === '/api/v1/issuance/start') {
+      if (options.startFailure === 'invalid_offer') {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: 'invalid_credential_offer',
+            error_description: 'Mock: offer rejected by wallet backend.',
+          }),
+        })
+        return
+      }
+      if (options.startFailure === 'network') {
+        await route.abort('failed')
+        return
+      }
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(buildStartIssuanceBody(options.startProfile)),
+      })
+      return
+    }
+
+    const consentMatch = /^\/api\/v1\/issuance\/([^/]+)\/consent$/.exec(path)
+    if (method === 'POST' && consentMatch) {
+      const sessionId = consentMatch[1]
+      let body: { accepted?: boolean } = {}
+      try {
+        body = (req.postDataJSON() as { accepted?: boolean }) ?? {}
+      } catch {
+        body = {}
+      }
+
+      if (body.accepted === false) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ session_id: sessionId, next_action: 'rejected' }),
+        })
+        return
+      }
+
+      if (options.startProfile === 'auth_code') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            session_id: sessionId,
+            next_action: 'redirect',
+            authorization_url: `${MOCK_AUTH_BASE}/authorize?e2e=1`,
+          }),
+        })
+        return
+      }
+
+      if (options.startProfile === 'pre_tx') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ session_id: sessionId, next_action: 'provide_tx_code' }),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ session_id: sessionId, next_action: 'none' }),
+      })
+      return
+    }
+
+    const eventsMatch = /^\/api\/v1\/issuance\/([^/]+)\/events$/.exec(path)
+    if (method === 'GET' && eventsMatch) {
+      const sessionId = eventsMatch[1]
+
+      if (options.startProfile === 'pre_tx') {
+        const body = await new Promise<string>((resolve) => {
+          resolvePreTxSseBody = resolve
+        })
+        await route.fulfill({
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive',
+          },
+          body,
+        })
+        return
+      }
+
+      const sse = sseProcessingFrame(sessionId) + sseCompletedFrame(sessionId)
+
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        },
+        body: sse,
+      })
+      return
+    }
+
+    if (method === 'POST' && /\/issuance\/[^/]+\/tx-code$/.test(path)) {
+      const sid = path.match(/\/issuance\/([^/]+)\//)?.[1] ?? E2E_SESSION_ID
+      const releaseSse = resolvePreTxSseBody
+      resolvePreTxSseBody = null
+      if (options.startProfile === 'pre_tx' && releaseSse) {
+        releaseSse(sseProcessingFrame(sid) + sseCompletedFrame(sid))
+      }
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ session_id: sid }),
+      })
+      return
+    }
+
+    if (method === 'POST' && /\/issuance\/[^/]+\/cancel$/.test(path)) {
+      await route.fulfill({ status: 204 })
+      return
+    }
+
+    if (method === 'GET' && path === '/api/v1/credentials') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ credentials: [] }),
+      })
+      return
+    }
+
+    const credMatch = /^\/api\/v1\/credentials\/([^/]+)$/.exec(path)
+    if (method === 'GET' && credMatch) {
+      const id = credMatch[1]
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id,
+          credential_configuration_id: E2E_CREDENTIAL_CONFIGURATION_ID,
+          format: 'dc+sd-jwt',
+          issuer: 'https://issuer.e2e.test',
+          status: 'active',
+          issued_at: new Date().toISOString(),
+          expires_at: null,
+          claims: { given_name: 'E2E' },
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 501,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'e2e_unmocked',
+        error_description: `No mock for ${method} ${path}`,
+      }),
+    })
+  })
+}

--- a/e2e/helpers/flow.ts
+++ b/e2e/helpers/flow.ts
@@ -1,0 +1,34 @@
+import { expect, type Page } from '@playwright/test'
+
+export async function clearClientStorage(page: Page) {
+  await page.goto('/registration')
+  await page.evaluate(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+}
+
+export async function completeRegistration(page: Page) {
+  await page.goto('/registration')
+  await page.getByRole('button', { name: /register/i }).click()
+  await expect(page.getByText('Scan the QR code')).toBeVisible({ timeout: 20_000 })
+}
+
+export async function openScanFromHome(page: Page) {
+  await page.getByRole('button', { name: 'Scan credential offer QR' }).click()
+  await expect(page).toHaveURL(/\/scan/)
+}
+
+export async function simulateQrScan(page: Page) {
+  // E2E harness buttons use `sr-only` (off-screen). Playwright still treats them as outside the
+  // viewport even with `force: true`, so trigger the DOM click handler directly.
+  const btn = page.getByTestId('e2e-simulate-scan')
+  await btn.waitFor({ state: 'attached' })
+  await btn.evaluate((el) => (el as HTMLButtonElement).click())
+}
+
+export async function simulateInvalidOfferLocal(page: Page) {
+  const btn = page.getByTestId('e2e-simulate-invalid-offer')
+  await btn.waitFor({ state: 'attached' })
+  await btn.evaluate((el) => (el as HTMLButtonElement).click())
+}

--- a/e2e/issuance.spec.ts
+++ b/e2e/issuance.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from '@playwright/test'
+
+import { installIssuanceApiMock } from './fixtures/api-mock'
+import {
+  clearClientStorage,
+  completeRegistration,
+  openScanFromHome,
+  simulateInvalidOfferLocal,
+  simulateQrScan,
+} from './helpers/flow'
+
+test.describe.configure({ mode: 'parallel' })
+
+test.beforeEach(async ({ page }) => {
+  await clearClientStorage(page)
+})
+
+test.describe('Authorization code flow', () => {
+  test('redirects to issuer authorization URL after consent', async ({ page }) => {
+    await installIssuanceApiMock(page, { startProfile: 'auth_code' })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateQrScan(page)
+
+    await expect(page.getByRole('button', { name: 'Issue VC' })).toBeVisible()
+    await page.getByRole('button', { name: 'Issue VC' }).click()
+
+    await page.waitForURL(/mock-authorize\.e2e\.test/, { timeout: 20_000 })
+    await expect(page).toHaveTitle(/E2E mock AS/)
+  })
+})
+
+test.describe('Pre-authorized code flow (no transaction code)', () => {
+  test('completes issuance and shows success screen', async ({ page }) => {
+    await installIssuanceApiMock(page, { startProfile: 'pre_no_tx' })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateQrScan(page)
+
+    await page.getByRole('button', { name: 'Issue VC' }).click()
+
+    await expect(
+      page.getByRole('heading', { name: 'Credential added to your wallet' })
+    ).toBeVisible({ timeout: 25_000 })
+  })
+})
+
+test.describe('Pre-authorized code flow (with transaction code)', () => {
+  test('accepts tx code and completes issuance', async ({ page }) => {
+    await installIssuanceApiMock(page, { startProfile: 'pre_tx' })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateQrScan(page)
+
+    await page.getByRole('button', { name: 'Issue VC' }).click()
+
+    await expect(page.getByText('Transaction Code Required')).toBeVisible()
+    const input = page.getByRole('textbox', { name: 'Transaction code' })
+    // Boxed numeric TX UI keeps the real `<input>` in `sr-only`; fill needs `force`.
+    await input.fill('123456', { force: true })
+    await page.getByRole('button', { name: 'Submit Code' }).click()
+
+    await expect(
+      page.getByRole('heading', { name: 'Credential added to your wallet' })
+    ).toBeVisible({ timeout: 25_000 })
+  })
+})
+
+test.describe('User rejection flow', () => {
+  test('declines offer via consent and returns to scan', async ({ page }) => {
+    await installIssuanceApiMock(page, { startProfile: 'pre_no_tx' })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateQrScan(page)
+
+    await page.getByRole('button', { name: 'Cancel' }).click()
+
+    await expect(page).toHaveURL(/\/scan/, { timeout: 15_000 })
+  })
+})
+
+test.describe('Error handling', () => {
+  test('shows error when backend rejects offer (invalid_credential_offer)', async ({
+    page,
+  }) => {
+    await installIssuanceApiMock(page, {
+      startProfile: 'pre_no_tx',
+      startFailure: 'invalid_offer',
+    })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateQrScan(page)
+
+    await expect(page.getByText(/Mock: offer rejected/i)).toBeVisible({
+      timeout: 20_000,
+    })
+  })
+
+  test('shows error when issuance/start fails at network layer', async ({ page }) => {
+    await installIssuanceApiMock(page, {
+      startProfile: 'pre_no_tx',
+      startFailure: 'network',
+    })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateQrScan(page)
+
+    await expect(page.getByRole('button', { name: 'Scan again' })).toBeVisible({
+      timeout: 20_000,
+    })
+  })
+
+  test('shows error for locally invalid scan payload', async ({ page }) => {
+    await installIssuanceApiMock(page, { startProfile: 'pre_no_tx' })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateInvalidOfferLocal(page)
+
+    await expect(
+      page.getByText(/The scanned QR code does not contain a valid credential offer/i)
+    ).toBeVisible({
+      timeout: 15_000,
+    })
+  })
+})
+
+test.describe('Credential storage integration', () => {
+  test('can open issued credential from success screen', async ({ page }) => {
+    await installIssuanceApiMock(page, { startProfile: 'pre_no_tx' })
+    await completeRegistration(page)
+    await openScanFromHome(page)
+    await simulateQrScan(page)
+
+    await page.getByRole('button', { name: 'Issue VC' }).click()
+    await expect(
+      page.getByRole('heading', { name: 'Credential added to your wallet' })
+    ).toBeVisible({ timeout: 25_000 })
+
+    await page.getByRole('button', { name: 'View Credential' }).click()
+    await expect(page.getByText('Credential Details')).toBeVisible()
+    await page.getByRole('button', { name: 'Show All' }).click()
+    await expect(page.getByText('E2E', { exact: true })).toBeVisible()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.57.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -943,6 +944,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -4093,6 +4110,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "format": "prettier . --check",
     "format:write": "prettier . --write",
     "test": "vitest run",
+    "build:e2e": "tsc -b && vite build --mode e2e",
+    "test:e2e": "playwright test",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -21,6 +23,7 @@
     "react-router-dom": "^7.13.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@eslint/js": "^9.39.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: 'e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    actionTimeout: 20_000,
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npm run build:e2e && vite preview --host 127.0.0.1 --port 4173 --strictPort',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: 'npm run build:e2e && vite preview --host 127.0.0.1 --port 4173 --strictPort',
+    command:
+      'npm run build:e2e && vite preview --host 127.0.0.1 --port 4173 --strictPort',
     url: 'http://127.0.0.1:4173',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/src/e2e/scan-sample-offer.ts
+++ b/src/e2e/scan-sample-offer.ts
@@ -1,0 +1,14 @@
+/**
+ * Stable credential-offer string for E2E (must parse via `parseCredentialOfferInput`).
+ * Only referenced from ScanPage when `import.meta.env.VITE_E2E === 'true'` (e2e build).
+ */
+export const E2E_CREDENTIAL_CONFIGURATION_ID = 'e2e_pid_v1'
+
+const inlineOffer = {
+  credential_issuer: 'https://issuer.example.com',
+  credential_configuration_ids: [E2E_CREDENTIAL_CONFIGURATION_ID],
+}
+
+export const E2E_SCAN_SAMPLE_OFFER =
+  'openid-credential-offer://?credential_offer=' +
+  encodeURIComponent(JSON.stringify(inlineOffer))

--- a/src/pages/ScanPage.tsx
+++ b/src/pages/ScanPage.tsx
@@ -10,6 +10,7 @@ import type { IssuanceApiError } from '../types/issuance'
 import { issuanceUserMessage } from '../utils/issuanceErrors'
 import { parseCredentialOfferInput } from '../utils/credentialOffer'
 import illuWallet from '../assets/illu-wallet.png'
+import { E2E_SCAN_SAMPLE_OFFER } from '../e2e/scan-sample-offer'
 
 type ScanStatus = 'idle' | 'scanning' | 'processing' | 'done'
 type FacingMode = 'environment' | 'user'
@@ -304,6 +305,31 @@ export function ScanPage() {
             </button>
           )}
         </section>
+
+        {import.meta.env.VITE_E2E === 'true' && !showFullscreenStatus && (
+          <>
+            <button
+              type="button"
+              data-testid="e2e-simulate-scan"
+              tabIndex={-1}
+              aria-hidden
+              className="sr-only"
+              onClick={() => void handleDecodedValue(E2E_SCAN_SAMPLE_OFFER)}
+            >
+              E2E simulate scan
+            </button>
+            <button
+              type="button"
+              data-testid="e2e-simulate-invalid-offer"
+              tabIndex={-1}
+              aria-hidden
+              className="sr-only"
+              onClick={() => void handleDecodedValue('not-a-credential-offer')}
+            >
+              E2E simulate invalid offer
+            </button>
+          </>
+        )}
       </div>
     </PageContainer>
   )

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
@@ -13,5 +13,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 })


### PR DESCRIPTION
## Summary
Adds Playwright end-to-end tests for the full issuance journey (scan → consent → issuance outcomes) with deterministic API mocking, and wires them into CI.

## What changed
- **Playwright** — `playwright.config.ts`, `npm run build:e2e` / `npm run test:e2e`
- **Scenarios** — Authorization code (redirect after consent), pre-authorized with and without transaction code, user rejection (Cancel → scan), invalid offer, network failure on start, locally invalid QR payload
- **Credential path** — Success → View credential → details (claims revealed via Show All)
- **Mocks** — `e2e/fixtures/api-mock.ts` intercepts same-origin `/api/v1/**` and mock issuer origin; SSE `completed` for `pre_tx` is deferred until `POST .../tx-code` so the TX UI is not raced
- **E2E harness** — When `VITE_E2E` is set, `ScanPage` exposes hidden controls to simulate valid/invalid scans
- **CI** — New `e2e` job: `npm ci`, `playwright install --with-deps chromium`, `npm run test:e2e`
- **Tooling** — `tsconfig.node.json` includes `playwright.config.ts`; Vitest excludes `e2e/**`

## How to test locally
```bash
npm ci
npx playwright install chromium
npm run test:e2e
```
Closes https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/47