### PR TITLE
fix(api): handle 502 Bad Gateway and metadata errors per OpenAPI (#44)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -34,6 +34,14 @@ export class ApiError extends Error {
 
 const REQUEST_TIMEOUT_MS = 15_000
 
+/** OpenAPI: 502 on issuance routes when metadata endpoints are unreachable. */
+const HTTP_STATUS_BAD_GATEWAY = 502
+
+const GATEWAY_METADATA_ERROR_CODES = new Set([
+  'issuer_metadata_fetch_failed',
+  'auth_server_metadata_fetch_failed',
+])
+
 async function fetchWithTimeout(
   input: string,
   init: RequestInit,
@@ -75,16 +83,39 @@ async function parseApiErrorPayload(response: Response): Promise<ApiErrorPayload
   }
 }
 
+function messageForBadGateway(
+  method: 'GET' | 'POST',
+  path: string,
+  payload: ApiErrorPayload
+): string {
+  if (payload.errorDescription) {
+    return payload.errorDescription
+  }
+  if (payload.errorCode && GATEWAY_METADATA_ERROR_CODES.has(payload.errorCode)) {
+    return payload.errorCode === 'issuer_metadata_fetch_failed'
+      ? 'Could not reach the credential issuer metadata endpoint (502 Bad Gateway).'
+      : 'Could not reach the authorization server metadata endpoint (502 Bad Gateway).'
+  }
+  if (payload.errorCode) {
+    return `${method} ${path} failed with 502 (${payload.errorCode}).`
+  }
+  return `The wallet backend could not reach the credential issuer or authorization server (${method} ${path}, 502). Please try again.`
+}
+
 async function buildApiError(
   method: 'GET' | 'POST',
   path: string,
   response: Response
 ): Promise<ApiError> {
-  const { errorCode, errorDescription } = await parseApiErrorPayload(response)
+  const payload = await parseApiErrorPayload(response)
   const fallbackMessage = `${method} ${path} failed with ${response.status}`
-  return new ApiError(response.status, errorDescription ?? fallbackMessage, {
-    errorCode,
-    errorDescription,
+  const message =
+    response.status === HTTP_STATUS_BAD_GATEWAY
+      ? messageForBadGateway(method, path, payload)
+      : (payload.errorDescription ?? fallbackMessage)
+  return new ApiError(response.status, message, {
+    errorCode: payload.errorCode,
+    errorDescription: payload.errorDescription,
   })
 }
 async function authHeaders(): Promise<Record<string, string>> {

--- a/src/api/tests/client.test.ts
+++ b/src/api/tests/client.test.ts
@@ -132,6 +132,97 @@ describe('api client', () => {
     await expect(apiGet('/network')).rejects.toThrow('network down')
   })
 
+  it('apiPost maps 502 with OpenAPI issuer_metadata_fetch_failed and no description', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 502,
+          json: async () => ({ error: 'issuer_metadata_fetch_failed' }),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiPost('/issuance/start', { offer: 'x' })).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 502,
+      errorCode: 'issuer_metadata_fetch_failed',
+      errorDescription: null,
+      message:
+        'Could not reach the credential issuer metadata endpoint (502 Bad Gateway).',
+    })
+  })
+
+  it('apiPost maps 502 with auth_server_metadata_fetch_failed and no description', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 502,
+          json: async () => ({ error: 'auth_server_metadata_fetch_failed' }),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiPost('/issuance/start', { offer: 'x' })).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 502,
+      errorCode: 'auth_server_metadata_fetch_failed',
+      errorDescription: null,
+      message:
+        'Could not reach the authorization server metadata endpoint (502 Bad Gateway).',
+    })
+  })
+
+  it('apiPost prefers error_description on 502 when present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 502,
+          json: async () => ({
+            error: 'issuer_metadata_fetch_failed',
+            error_description:
+              'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer',
+          }),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiPost('/issuance/start', { offer: 'x' })).rejects.toMatchObject({
+      status: 502,
+      errorCode: 'issuer_metadata_fetch_failed',
+      errorDescription:
+        'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer',
+      message:
+        'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer',
+    })
+  })
+
+  it('apiPost uses gateway-specific fallback when 502 body has no ErrorResponse fields', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: false,
+          status: 502,
+          json: async () => ({}),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await expect(apiPost('/issuance/start', { offer: 'x' })).rejects.toMatchObject({
+      status: 502,
+      errorCode: null,
+      errorDescription: null,
+      message:
+        'The wallet backend could not reach the credential issuer or authorization server (POST /issuance/start, 502). Please try again.',
+    })
+  })
+
   it('uses fallback api error message when error payload is not an object', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/api/tests/issuance.test.ts
+++ b/src/api/tests/issuance.test.ts
@@ -162,7 +162,7 @@ describe('startIssuanceSession', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('throws ApiError when the server returns 502', async () => {
+  it('throws ApiError when the server returns 502 with empty ErrorResponse', async () => {
     const fetchMock = vi.fn(async () => mockResponse({ ok: false, status: 502 }))
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
@@ -171,7 +171,35 @@ describe('startIssuanceSession', () => {
     )
     expect(err).toBeInstanceOf(ApiError)
     expect((err as ApiError).status).toBe(502)
+    expect((err as ApiError).errorCode).toBeNull()
+    expect((err as ApiError).message).toContain('502')
+    expect((err as ApiError).message).toContain('credential issuer')
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('parses 502 issuer_metadata_fetch_failed ErrorResponse into ApiError', async () => {
+    const fetchMock = vi.fn(async () =>
+      mockResponse({
+        ok: false,
+        status: 502,
+        json: async () => ({
+          error: 'issuer_metadata_fetch_failed',
+          error_description:
+            'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer',
+        }),
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    const err = await startIssuanceSession('openid-credential-offer://?x=y').catch(
+      (e) => e
+    )
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(502)
+    expect((err as ApiError).errorCode).toBe('issuer_metadata_fetch_failed')
+    expect((err as ApiError).errorDescription).toBe(
+      'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer'
+    )
   })
 
   it('returns session with tx_code when pre-authorized flow requires one', async () => {

--- a/src/components/issuance/IssuanceErrorCard.tsx
+++ b/src/components/issuance/IssuanceErrorCard.tsx
@@ -28,7 +28,7 @@ export function IssuanceErrorCard({
             className="absolute inset-8 m-auto h-[calc(100%-4rem)] w-[calc(100%-4rem)] object-contain"
           />
         </div>
-        <div className="text-base text-slate-700">{message}</div>
+        <div className="whitespace-pre-line text-base text-slate-700">{message}</div>
         <button
           type="button"
           onClick={onRetry}

--- a/src/utils/issuanceErrors.ts
+++ b/src/utils/issuanceErrors.ts
@@ -26,8 +26,33 @@ export function toIssuanceApiError(error: unknown): IssuanceApiError {
   }
 }
 
+function userLeadFor502MetadataError(error: IssuanceApiError): string | null {
+  if (error.error === 'issuer_metadata_fetch_failed') {
+    return "We couldn't load information from the credential issuer. Your wallet is working; the problem is on the issuer or network side."
+  }
+  if (error.error === 'auth_server_metadata_fetch_failed') {
+    return "We couldn't load the issuer's authorization server details. Your wallet is working; the issuer's login service may be temporarily unavailable."
+  }
+  return null
+}
+
 export function issuanceUserMessage(error: IssuanceApiError): string {
-  if (error.error_description) return error.error_description
+  // OpenAPI 502 + ErrorResponse: surface issuer/AS context before generic copy.
+  if (error.httpStatus === 502) {
+    const lead = userLeadFor502MetadataError(error)
+    const detail = error.error_description?.trim() ?? null
+    if (lead) {
+      return detail ? `${lead}\n\n${detail}` : lead
+    }
+    if (detail) {
+      return detail
+    }
+    return "We couldn't reach the credential issuer or its authorization server. This is usually temporary and not caused by your wallet. Please try again shortly."
+  }
+
+  if (error.error_description?.trim()) {
+    return error.error_description.trim()
+  }
 
   switch (error.error) {
     case 'invalid_credential_offer':

--- a/src/utils/tests/issuanceErrors.test.ts
+++ b/src/utils/tests/issuanceErrors.test.ts
@@ -112,4 +112,50 @@ describe('issuanceUserMessage', () => {
       })
     ).toContain('could not be completed')
   })
+
+  describe('502 Bad Gateway (OpenAPI issuance/start)', () => {
+    it('shows issuer-focused lead and appends server error_description for issuer_metadata_fetch_failed', () => {
+      const msg = issuanceUserMessage({
+        httpStatus: 502,
+        error: 'issuer_metadata_fetch_failed',
+        error_description:
+          'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer',
+      })
+      expect(msg).toContain('credential issuer')
+      expect(msg).toContain('Your wallet is working')
+      expect(msg).toContain(
+        'https://issuer.example.eu/.well-known/openid-credential-issuer'
+      )
+    })
+
+    it('shows authorization-server lead for auth_server_metadata_fetch_failed', () => {
+      const msg = issuanceUserMessage({
+        httpStatus: 502,
+        error: 'auth_server_metadata_fetch_failed',
+        error_description: null,
+      })
+      expect(msg).toContain('authorization server')
+      expect(msg).toContain('Your wallet is working')
+    })
+
+    it('uses error_description alone for unknown 502 error codes when description is set', () => {
+      expect(
+        issuanceUserMessage({
+          httpStatus: 502,
+          error: 'internal_error',
+          error_description: 'Upstream timeout contacting partner.',
+        })
+      ).toBe('Upstream timeout contacting partner.')
+    })
+
+    it('uses generic issuer-side copy for 502 when code and description are missing', () => {
+      expect(
+        issuanceUserMessage({
+          httpStatus: 502,
+          error: 'internal_error',
+          error_description: null,
+        })
+      ).toMatch(/not caused by your wallet/i)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Implements OpenAPI-aligned handling for **502 Bad Gateway** on issuance flows, specifically `issuer_metadata_fetch_failed` and `auth_server_metadata_fetch_failed` from the `ErrorResponse` body (`openapi/openapi.yaml` ~170–184).

## Changes
- **`src/api/client.ts`** — When the response status is **502**, build `ApiError.message` using parsed `error` / `error_description`: known metadata codes, other codes with context, or a clear fallback when the body is empty.
- **`src/utils/issuanceErrors.ts`** — **`issuanceUserMessage()`** treats **502** first: issuer- and authorization-server–focused copy (“wallet is working”), optional second paragraph from `error_description` (e.g. well-known URL).
- **`src/components/issuance/IssuanceErrorCard.tsx`** — **`whitespace-pre-line`** so lead + detail render on separate lines.

## Tests
- **`src/api/tests/client.test.ts`** — 502 variants (issuer, auth server, description preferred, empty body).
- **`src/api/tests/issuance.test.ts`** — `startIssuanceSession` with empty 502 and full `issuer_metadata_fetch_failed` payload.
- **`src/utils/tests/issuanceErrors.test.ts`** — User-facing strings for 502 metadata and generic 502.

## Out of scope
- **Automatic retry** on 502 (ticket optional item): not added; existing client contract keeps non-2xx as throw-without-retry.

## How to verify
```bash
npm run format && npm run lint && npm run test -- --run
```

Closes https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/44