### PR TITLE
feat(dev): API and SSE debug logging behind VITE_DEBUG_API (#46)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 # `/api/v1` is appended automatically when missing.
 VITE_API_BASE_URL=http://localhost:3000
 
+# When set to `true`, logs API requests/responses and SSE events to the browser console
+# (Authorization tokens are redacted). Omit or set to anything else in production builds.
+# VITE_DEBUG_API=true
+
 # Optional allowlist for accepting *plain https* QR payloads as credential-offer URLs.
 # Comma-separated host[:port] entries (no scheme).
 #

--- a/README.md
+++ b/README.md
@@ -62,12 +62,17 @@ The application uses Vite environment variables.
   If omitted, the app only accepts conservative plain-HTTPS offers (path must contain `credential-offer`).  
   `openid-credential-offer://...` links remain accepted regardless.
 
+- `VITE_DEBUG_API` (optional)  
+  Set to `true` to enable **`console.debug`** logging of all traffic from `apiGet` / `apiPost` and the issuance SSE stream (`useSseStream`): request method and path, redacted headers (`Authorization` is never logged in full), response status and JSON bodies, and parsed SSE events.  
+  **Do not** enable in production builds. Leave unset (default) so no API traffic is logged.
+
 Create `.env` in the project root:
 
 ```bash
 VITE_API_BASE_URL=http://localhost:3000
 # Optional:
 # VITE_ALLOWED_CREDENTIAL_OFFER_HOSTS=issuer.example.com,wallet.example.org
+# VITE_DEBUG_API=true
 ```
 
 You can also copy `.env.example` to `.env` (or `.env.local`) and adjust values.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,10 @@
-import { getApiBaseUrl } from '../utils/env'
 import { getBearerToken } from '../auth/authService'
+import {
+  debugLogApiErrorResponse,
+  debugLogApiRequest,
+  debugLogApiResponse,
+} from '../utils/debugApiLogger'
+import { getApiBaseUrl } from '../utils/env'
 
 /**
  * Spec-compliant API client.
@@ -12,6 +17,9 @@ import { getBearerToken } from '../auth/authService'
  * - No undocumented endpoints may be called through this module.
  * - Every request carries an `Authorization: Bearer <JWT>` header obtained
  *   from the auth service (spec: BearerAuth security scheme).
+ *
+ * When `VITE_DEBUG_API=true`, requests and responses are logged with
+ * `console.debug` (Authorization values redacted; large `offer` bodies truncated).
  */
 
 export class ApiError extends Error {
@@ -95,46 +103,58 @@ async function authHeaders(): Promise<Record<string, string>> {
 }
 
 export async function apiGet<T>(path: string): Promise<T> {
+  const headers = await authHeaders()
+  debugLogApiRequest('GET', path, { headers })
+
   const response = await fetchWithTimeout(
     `${getApiBaseUrl()}${path}`,
-    {
-      headers: await authHeaders(),
-    },
+    { headers },
     REQUEST_TIMEOUT_MS
   )
 
   if (!response.ok) {
+    await debugLogApiErrorResponse('GET', path, response)
     throw await buildApiError('GET', path, response)
   }
 
-  return (await response.json()) as T
+  const data = (await response.json()) as T
+  debugLogApiResponse('GET', path, response, data)
+  return data
 }
 
 export async function apiPost<TResponse, TBody>(
   path: string,
   body: TBody
 ): Promise<TResponse> {
+  const serialized = JSON.stringify(body)
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(await authHeaders()),
+  }
+  debugLogApiRequest('POST', path, { headers, body: serialized })
+
   const response = await fetchWithTimeout(
     `${getApiBaseUrl()}${path}`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(await authHeaders()),
-      },
-      body: JSON.stringify(body),
+      headers,
+      body: serialized,
     },
     REQUEST_TIMEOUT_MS
   )
 
   if (!response.ok) {
+    await debugLogApiErrorResponse('POST', path, response)
     throw await buildApiError('POST', path, response)
   }
 
   // 204 No Content — spec uses this for DELETE-like operations (e.g. cancel session).
   if (response.status === 204) {
+    debugLogApiResponse('POST', path, response, null)
     return undefined as TResponse
   }
 
-  return (await response.json()) as TResponse
+  const data = (await response.json()) as TResponse
+  debugLogApiResponse('POST', path, response, data)
+  return data
 }

--- a/src/api/tests/client.test.ts
+++ b/src/api/tests/client.test.ts
@@ -9,15 +9,30 @@ type MockResponse = {
   ok: boolean
   status: number
   json: () => Promise<unknown>
+  clone: () => { text: () => Promise<string> }
 }
 
 function makeResponse(
   partial: Partial<MockResponse> & Pick<MockResponse, 'ok' | 'status'>
 ): MockResponse {
+  const json = partial.json ?? (async () => ({}))
   return {
     ok: partial.ok,
     status: partial.status,
-    json: partial.json ?? (async () => ({})),
+    json,
+    clone() {
+      return {
+        async text() {
+          try {
+            const data = await json()
+            if (typeof data === 'string') return data
+            return JSON.stringify(data)
+          } catch {
+            return ''
+          }
+        },
+      }
+    },
   }
 }
 
@@ -150,5 +165,29 @@ describe('api client', () => {
       errorDescription: null,
       message: 'POST /plain-error failed with 400',
     })
+  })
+
+  it('when VITE_DEBUG_API is true, logs requests and redacts Authorization', async () => {
+    vi.stubEnv('VITE_DEBUG_API', 'true')
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        makeResponse({
+          ok: true,
+          status: 200,
+          json: async () => ({ x: 1 }),
+        })
+      ) as unknown as typeof fetch
+    )
+
+    await apiGet('/safe')
+
+    expect(debugSpy).toHaveBeenCalled()
+    const combined = debugSpy.mock.calls.map((c) => JSON.stringify(c)).join('\n')
+    expect(combined).toContain('Bearer [REDACTED]')
+    expect(combined).not.toContain('mock.jwt.token')
+    expect(combined).toContain('[API]')
   })
 })

--- a/src/hooks/test/useSseStream.test.ts
+++ b/src/hooks/test/useSseStream.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../auth/authService', () => ({
 
 vi.mock('../../utils/env', () => ({
   getApiBaseUrl: vi.fn(() => 'http://api.test/api/v1'),
+  isDebugApiEnabled: vi.fn(() => false),
 }))
 
 import { getBearerToken } from '../../auth/authService'

--- a/src/hooks/useSseStream.ts
+++ b/src/hooks/useSseStream.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
+import { debugLogSse } from '../utils/debugApiLogger'
 import { getApiBaseUrl } from '../utils/env'
 import { getBearerToken } from '../auth/authService'
 import type {
@@ -65,6 +66,9 @@ function parseSseFrame(raw: string): SseEvent | null {
  * The frontend MUST open this stream immediately after receiving a successful
  * /consent response and maintain the connection until a terminal event
  * (completed or failed) is received.
+ *
+ * When `VITE_DEBUG_API=true`, SSE requests (redacted auth), HTTP response status,
+ * and parsed event payloads are logged via `console.debug`.
  */
 export function useSseStream(): UseSseStreamReturn {
   const [streamStatus, setStreamStatus] = useState<SseStreamStatus>({ status: 'idle' })
@@ -102,6 +106,15 @@ export function useSseStream(): UseSseStreamReturn {
 
         const url = `${getApiBaseUrl()}/issuance/${encodeURIComponent(sessionId)}/events`
 
+        debugLogSse('request', {
+          method: 'GET',
+          url,
+          headers: {
+            Authorization: 'Bearer [REDACTED]',
+            Accept: 'text/event-stream',
+          },
+        })
+
         let response: Response
         try {
           response = await fetch(url, {
@@ -121,6 +134,8 @@ export function useSseStream(): UseSseStreamReturn {
           })
           return
         }
+
+        debugLogSse('response', { status: response.status, ok: response.ok })
 
         if (!response.ok) {
           setStreamStatus({
@@ -166,6 +181,8 @@ export function useSseStream(): UseSseStreamReturn {
               if (!frame.trim()) continue
               const event = parseSseFrame(frame)
               if (!event) continue
+
+              debugLogSse(`event:${event.event}`, event)
 
               if (event.event === 'processing') {
                 const e = event as SseProcessingFrame

--- a/src/utils/debugApiLogger.ts
+++ b/src/utils/debugApiLogger.ts
@@ -1,0 +1,98 @@
+import { isDebugApiEnabled } from './env'
+
+function redactAuthorization(value: string): string {
+  if (/^Bearer\s+/i.test(value)) {
+    return 'Bearer [REDACTED]'
+  }
+  return '[REDACTED]'
+}
+
+function headersInitToRedactedRecord(headers: HeadersInit): Record<string, string> {
+  const h = new Headers(headers)
+  const out: Record<string, string> = {}
+  h.forEach((value, key) => {
+    out[key] = key.toLowerCase() === 'authorization' ? redactAuthorization(value) : value
+  })
+  return out
+}
+
+/** Truncate large credential-offer strings in POST bodies for readable logs. */
+export function sanitizeRequestBodyForLog(body: unknown): unknown {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return body
+  const o = { ...(body as Record<string, unknown>) }
+  if (typeof o.offer === 'string' && o.offer.length > 200) {
+    const len = o.offer.length
+    o.offer = `${o.offer.slice(0, 200)}… (${len} chars total)`
+  }
+  return o
+}
+
+export function debugLogApiRequest(
+  method: 'GET' | 'POST',
+  path: string,
+  init: { headers?: HeadersInit; body?: string | null }
+): void {
+  if (!isDebugApiEnabled()) return
+
+  let bodyLog: unknown
+  if (init.body != null && init.body !== '') {
+    try {
+      bodyLog = sanitizeRequestBodyForLog(JSON.parse(init.body) as unknown)
+    } catch {
+      bodyLog = '[non-JSON body]'
+    }
+  }
+
+  console.debug(`[API] → ${method} ${path}`, {
+    headers: init.headers ? headersInitToRedactedRecord(init.headers) : {},
+    body: bodyLog,
+  })
+}
+
+export function debugLogApiResponse(
+  method: 'GET' | 'POST',
+  path: string,
+  response: Response,
+  body: unknown
+): void {
+  if (!isDebugApiEnabled()) return
+  console.debug(`[API] ← ${method} ${path}`, {
+    status: response.status,
+    ok: response.ok,
+    body,
+  })
+}
+
+export async function debugLogApiErrorResponse(
+  method: 'GET' | 'POST',
+  path: string,
+  response: Response
+): Promise<void> {
+  if (!isDebugApiEnabled()) return
+  try {
+    const text = await response.clone().text()
+    let body: unknown = text.length > 0 ? text : null
+    if (typeof body === 'string' && body.length > 0) {
+      try {
+        body = JSON.parse(body) as unknown
+      } catch {
+        /* keep raw string */
+      }
+    }
+    console.debug(`[API] ← ${method} ${path} (error)`, {
+      status: response.status,
+      body,
+    })
+  } catch {
+    /* ignore logging failures */
+  }
+}
+
+export function debugLogSse(message: string, detail?: unknown): void {
+  if (!isDebugApiEnabled()) return
+  if (detail !== undefined) {
+    console.debug(`[SSE] ${message}`, detail)
+  } else {
+    console.debug(`[SSE] ${message}`)
+  }
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,3 +3,8 @@ export function getApiBaseUrl(): string {
   const normalized = configured.replace(/\/+$/, '')
   return normalized.endsWith('/api/v1') ? normalized : `${normalized}/api/v1`
 }
+
+/** When `VITE_DEBUG_API=true`, request/response and SSE traffic are logged (tokens redacted). */
+export function isDebugApiEnabled(): boolean {
+  return import.meta.env.VITE_DEBUG_API === 'true'
+}

--- a/src/utils/tests/debugApiLogger.test.ts
+++ b/src/utils/tests/debugApiLogger.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeRequestBodyForLog } from '../debugApiLogger'
+
+describe('sanitizeRequestBodyForLog', () => {
+  it('truncates long offer strings', () => {
+    const offer = 'x'.repeat(300)
+    const out = sanitizeRequestBodyForLog({ offer }) as { offer: string }
+    expect(out.offer).toContain('…')
+    expect(out.offer).toContain('300 chars total')
+    expect(out.offer.length).toBeLessThan(250)
+  })
+
+  it('leaves short bodies unchanged', () => {
+    expect(sanitizeRequestBodyForLog({ offer: 'short' })).toEqual({ offer: 'short' })
+  })
+})

--- a/src/utils/tests/env.test.ts
+++ b/src/utils/tests/env.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getApiBaseUrl } from '../env'
+import { getApiBaseUrl, isDebugApiEnabled } from '../env'
 
 describe('getApiBaseUrl', () => {
   afterEach(() => {
@@ -19,5 +19,25 @@ describe('getApiBaseUrl', () => {
   it('does not append /api/v1 when already provided', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com/api/v1')
     expect(getApiBaseUrl()).toBe('https://api.example.com/api/v1')
+  })
+})
+
+describe('isDebugApiEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('is false when VITE_DEBUG_API is unset or not the string "true"', () => {
+    vi.stubEnv('VITE_DEBUG_API', undefined)
+    expect(isDebugApiEnabled()).toBe(false)
+    vi.stubEnv('VITE_DEBUG_API', 'false')
+    expect(isDebugApiEnabled()).toBe(false)
+    vi.stubEnv('VITE_DEBUG_API', '1')
+    expect(isDebugApiEnabled()).toBe(false)
+  })
+
+  it('is true only when VITE_DEBUG_API is exactly "true"', () => {
+    vi.stubEnv('VITE_DEBUG_API', 'true')
+    expect(isDebugApiEnabled()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
Adds an opt-in debug mode (`VITE_DEBUG_API=true`) that logs wallet backend traffic to the browser console for local troubleshooting, without changing OpenAPI request behavior.

## What’s included
- **`VITE_DEBUG_API`** — `isDebugApiEnabled()` in `src/utils/env.ts` (only the string `"true"` enables logging).
- **REST** — `apiGet` / `apiPost` log outbound requests and responses via `console.debug`; `Authorization` is redacted; large `offer` strings in POST bodies are truncated.
- **Errors** — Non-2xx responses are logged using `response.clone()` so the existing error parsing path is unchanged.
- **SSE** — `useSseStream` logs the stream request (redacted auth), HTTP status, and each parsed event when debug is on.
- **Docs** — README + `.env.example`.

## Security / production
- Default: no logging (`VITE_DEBUG_API` unset or not `"true"`).
- Do not set `VITE_DEBUG_API=true` for production builds.

## Verify
```bash
npm run format && npm run lint && npm run test -- --run && npm run build
```

Closes https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/46