### PR TITLE
fix(ui): static credential header on detail page while scrolling claims (#51)

### DIFF
--- a/src/pages/CredentialDetailPage.tsx
+++ b/src/pages/CredentialDetailPage.tsx
@@ -204,12 +204,17 @@ function CredentialDetailBody({ credentialId }: { credentialId: string }) {
 
 function CredentialDetailContent({ credential }: { credential: CredentialRecord }) {
   return (
-    <section className="flex-1 overflow-y-auto bg-white">
-      <div className="bg-[#E9ECEF] py-4">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 bg-[#E9ECEF] py-4">
         <CredentialHeaderCard credential={credential} />
       </div>
-      <ClaimsSection claims={credential.claims} />
-    </section>
+      <section
+        className="min-h-0 flex-1 overflow-y-auto bg-white"
+        aria-label="Credential claims"
+      >
+        <ClaimsSection claims={credential.claims} />
+      </section>
+    </div>
   )
 }
 

--- a/src/pages/CredentialDetailPage.tsx
+++ b/src/pages/CredentialDetailPage.tsx
@@ -158,30 +158,32 @@ function CredentialDetailBody({ credentialId }: { credentialId: string }) {
 
   return (
     <PageContainer fullWidth={true}>
-      <div className="flex min-h-screen w-full flex-col overflow-hidden rounded-none bg-[#E9ECEF] font-serif">
-        <Header
-          title={headerTitle}
-          hidePwaBanner={true}
-          leftSlot={
-            <button
-              type="button"
-              onClick={() => navigate(routes.credentials)}
-              className="h-10 w-10 rounded-full text-4xl leading-none text-white"
-              aria-label="Back to credentials"
-            >
-              ‹
-            </button>
-          }
-        />
+      <div className="flex h-dvh w-full flex-col overflow-hidden rounded-none bg-[#E9ECEF] font-serif">
+        <div className="shrink-0">
+          <Header
+            title={headerTitle}
+            hidePwaBanner={true}
+            leftSlot={
+              <button
+                type="button"
+                onClick={() => navigate(routes.credentials)}
+                className="h-10 w-10 rounded-full text-4xl leading-none text-white"
+                aria-label="Back to credentials"
+              >
+                ‹
+              </button>
+            }
+          />
+        </div>
 
         {loading && (
-          <section className="flex flex-1 items-center justify-center bg-[#E9ECEF] text-slate-600">
+          <section className="flex min-h-0 flex-1 items-center justify-center bg-[#E9ECEF] text-slate-600">
             Loading…
           </section>
         )}
 
         {!loading && error && (
-          <section className="flex flex-1 flex-col items-center justify-center gap-3 bg-[#E9ECEF] px-4 text-center">
+          <section className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 bg-[#E9ECEF] px-4 text-center">
             <p className="text-slate-800">Could not open this credential.</p>
             <p className="text-sm text-slate-600">{error.message}</p>
             <button


### PR DESCRIPTION
## Problem
On `/credentials/:id`, the issuer/title card scrolled away with long claim lists because it shared the same `overflow-y-auto` region as the claims.

## Change
- `CredentialHeaderCard` sits in a non-scrolling `shrink-0` region.
- Only `ClaimsSection` uses `flex-1 min-h-0 overflow-y-auto`.
- Parent uses `min-h-0` on the flex column so the scroll area sizes correctly.

## Scope
- `src/pages/CredentialDetailPage.tsx` only (no API / OpenAPI changes).

Closes https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/51