### PR TITLE
Add Missing Tenant Registration Response Validation

### DIFF
--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -366,12 +366,18 @@ describe('validateTenantRegistrationResponse', () => {
   })
 
   it('throws ContractError when tenant_id has invalid UUID pattern (missing dashes)', () => {
-    const input = { ...validTenantResponse, tenant_id: 'f47ac10b58cc4372a5670e02b2c3d479' }
+    const input = {
+      ...validTenantResponse,
+      tenant_id: 'f47ac10b58cc4372a5670e02b2c3d479',
+    }
     expect(() => validateTenantRegistrationResponse(input)).toThrow(ContractError)
   })
 
   it('throws ContractError when tenant_id has invalid UUID pattern (wrong length)', () => {
-    const input = { ...validTenantResponse, tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d47' }
+    const input = {
+      ...validTenantResponse,
+      tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d47',
+    }
     expect(() => validateTenantRegistrationResponse(input)).toThrow(ContractError)
   })
 

--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -4,6 +4,7 @@ import {
   validateStartIssuanceResponse,
   validateCredentialRecord,
   validateCredentialListResponse,
+  validateTenantRegistrationResponse,
 } from '../validation'
 import type { StartIssuanceResponse } from '../../types/issuance'
 import type { CredentialRecord } from '../../types/credential'
@@ -334,5 +335,76 @@ describe('validateCredentialListResponse', () => {
 
   it('throws ContractError when the response has no credentials field', () => {
     expect(() => validateCredentialListResponse({ items: [] })).toThrow()
+  })
+})
+
+describe('validateTenantRegistrationResponse', () => {
+  const validTenantResponse = {
+    tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    name: 'adorsys GmbH',
+  }
+
+  it('accepts a valid tenant registration response', () => {
+    const result = validateTenantRegistrationResponse(validTenantResponse)
+    expect(result).toEqual(validTenantResponse)
+  })
+
+  it('throws ContractError when tenant_id is missing', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { tenant_id: _, ...rest } = validTenantResponse
+    expect(() => validateTenantRegistrationResponse(rest)).toThrow(ContractError)
+  })
+
+  it('throws ContractError when tenant_id is not a string', () => {
+    const input = { ...validTenantResponse, tenant_id: 123 }
+    expect(() => validateTenantRegistrationResponse(input)).toThrow(ContractError)
+  })
+
+  it('throws ContractError when tenant_id is not a valid UUID format', () => {
+    const input = { ...validTenantResponse, tenant_id: 'not-a-uuid' }
+    expect(() => validateTenantRegistrationResponse(input)).toThrow(ContractError)
+  })
+
+  it('throws ContractError when tenant_id has invalid UUID pattern (missing dashes)', () => {
+    const input = { ...validTenantResponse, tenant_id: 'f47ac10b58cc4372a5670e02b2c3d479' }
+    expect(() => validateTenantRegistrationResponse(input)).toThrow(ContractError)
+  })
+
+  it('throws ContractError when tenant_id has invalid UUID pattern (wrong length)', () => {
+    const input = { ...validTenantResponse, tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d47' }
+    expect(() => validateTenantRegistrationResponse(input)).toThrow(ContractError)
+  })
+
+  it('accepts valid UUID with uppercase letters', () => {
+    const input = {
+      ...validTenantResponse,
+      tenant_id: 'F47AC10B-58CC-4372-A567-0E02B2C3D479',
+    }
+    const result = validateTenantRegistrationResponse(input)
+    expect(result.tenant_id).toBe('F47AC10B-58CC-4372-A567-0E02B2C3D479')
+  })
+
+  it('throws ContractError when name is missing', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { name: _, ...rest } = validTenantResponse
+    expect(() => validateTenantRegistrationResponse(rest)).toThrow(ContractError)
+  })
+
+  it('throws ContractError when name is not a string', () => {
+    const input = { ...validTenantResponse, name: 123 }
+    expect(() => validateTenantRegistrationResponse(input)).toThrow(ContractError)
+  })
+
+  it('accepts empty string for name (valid per OpenAPI spec)', () => {
+    const input = { ...validTenantResponse, name: '' }
+    const result = validateTenantRegistrationResponse(input)
+    expect(result.name).toBe('')
+  })
+
+  it('throws ContractError when response is not an object', () => {
+    expect(() => validateTenantRegistrationResponse(null)).toThrow(ContractError)
+    expect(() => validateTenantRegistrationResponse('string')).toThrow(ContractError)
+    expect(() => validateTenantRegistrationResponse(123)).toThrow(ContractError)
+    expect(() => validateTenantRegistrationResponse([])).toThrow(ContractError)
   })
 })

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -30,6 +30,7 @@ import type {
   ConsentNextAction,
   TxCodeResponse,
 } from '../types/issuance'
+import type { TenantRegistrationResponse } from '../auth/tenant'
 
 export class ContractError extends Error {
   constructor(context: string, field: string, received: unknown) {
@@ -295,4 +296,24 @@ export function validateCredentialListResponse(raw: unknown): CredentialListResp
       }
     }),
   }
+}
+
+/**
+ * Validates a tenant registration response against the OpenAPI spec.
+ * Per the spec, both tenant_id (UUID format) and name (string) are required.
+ */
+export function validateTenantRegistrationResponse(raw: unknown): TenantRegistrationResponse {
+  const ctx = 'TenantRegistrationResponse'
+  const obj = requireObject(ctx, 'response', raw)
+
+  const tenant_id = requireString(ctx, 'tenant_id', obj.tenant_id)
+  // Validate UUID format (8-4-4-4-12 pattern)
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  if (!uuidRegex.test(tenant_id)) {
+    throw new ContractError(ctx, 'tenant_id', tenant_id)
+  }
+
+  const name = requireString(ctx, 'name', obj.name)
+
+  return { tenant_id, name }
 }

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -302,7 +302,9 @@ export function validateCredentialListResponse(raw: unknown): CredentialListResp
  * Validates a tenant registration response against the OpenAPI spec.
  * Per the spec, both tenant_id (UUID format) and name (string) are required.
  */
-export function validateTenantRegistrationResponse(raw: unknown): TenantRegistrationResponse {
+export function validateTenantRegistrationResponse(
+  raw: unknown
+): TenantRegistrationResponse {
   const ctx = 'TenantRegistrationResponse'
   const obj = requireObject(ctx, 'response', raw)
 

--- a/src/auth/tenant.ts
+++ b/src/auth/tenant.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '../utils/env'
+import { validateTenantRegistrationResponse } from '../api/validation'
 
 export type TenantRegistrationResponse = {
   tenant_id: string
@@ -47,10 +48,6 @@ export async function registerTenant(name: string): Promise<TenantRegistrationRe
     )
   }
 
-  const body = (await response.json()) as TenantRegistrationResponse
-  if (typeof body.tenant_id !== 'string' || !body.tenant_id) {
-    throw new Error('Tenant registration response is missing tenant_id')
-  }
-
-  return body
+  const body = await response.json()
+  return validateTenantRegistrationResponse(body)
 }

--- a/src/auth/tests/tenant.test.ts
+++ b/src/auth/tests/tenant.test.ts
@@ -67,7 +67,10 @@ describe('registerTenant', () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       status: 201,
-      json: async () => ({ tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479', name: 'Test' }),
+      json: async () => ({
+        tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        name: 'Test',
+      }),
     }))
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
@@ -139,7 +142,10 @@ describe('registerTenant', () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       status: 201,
-      json: async () => ({ tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479', name: 123 }),
+      json: async () => ({
+        tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        name: 123,
+      }),
     }))
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 

--- a/src/auth/tests/tenant.test.ts
+++ b/src/auth/tests/tenant.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { registerTenant, storeTenantId, getStoredTenantId } from '../tenant'
+import { ContractError } from '../../api/validation'
 
 const store: Record<string, string> = {}
 const localStorageMock = {
@@ -66,7 +67,7 @@ describe('registerTenant', () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       status: 201,
-      json: async () => ({ tenant_id: 'some-id', name: 'Test' }),
+      json: async () => ({ tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479', name: 'Test' }),
     }))
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
@@ -101,7 +102,7 @@ describe('registerTenant', () => {
     )
   })
 
-  it('throws when tenant_id is missing from the response', async () => {
+  it('throws ContractError when tenant_id is missing from the response', async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       status: 201,
@@ -109,6 +110,39 @@ describe('registerTenant', () => {
     }))
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await expect(registerTenant('Test')).rejects.toThrow('tenant_id')
+    await expect(registerTenant('Test')).rejects.toThrow(ContractError)
+  })
+
+  it('throws ContractError when tenant_id is not a valid UUID', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({ tenant_id: 'not-a-uuid', name: 'Test' }),
+    }))
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    await expect(registerTenant('Test')).rejects.toThrow(ContractError)
+  })
+
+  it('throws ContractError when name is missing from the response', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({ tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479' }), // no name
+    }))
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    await expect(registerTenant('Test')).rejects.toThrow(ContractError)
+  })
+
+  it('throws ContractError when name is not a string', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({ tenant_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479', name: 123 }),
+    }))
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    await expect(registerTenant('Test')).rejects.toThrow(ContractError)
   })
 })


### PR DESCRIPTION
The [`registerTenant()`](src/auth/tenant.ts:30) function in `src/auth/tenant.ts` performs minimal validation (only checks for `tenant_id` presence). It should fully validate against the OpenAPI `TenantRegistrationResponse` schema including the `name` field.

### OpenAPI Spec Reference
Lines 870-887 in [`openapi/openapi.yaml`](openapi/openapi.yaml:870)

### Tasks
- [x] Create `validateTenantRegistrationResponse()` function in validation module
- [x] Validate both `tenant_id` (UUID format) and `name` (string, required)
- [x] Update `registerTenant()` to use validation function
- [x] Add unit tests for validation function
- [x] Ensure proper error messages for validation failures