### PR TITLE
feat(auth): enforce unauthenticated POST /tenants usage and improve tenant registration comments

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,22 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.name='apiPost'][arguments.0.value='/tenants']",
+          message:
+            'POST /tenants is unauthenticated by spec (security: []); use raw fetch in auth/tenant.ts, never apiPost.',
+        },
+        {
+          selector:
+            "CallExpression[callee.name='apiPost'][arguments.0.type='TemplateLiteral'][arguments.0.quasis.length=1][arguments.0.quasis.0.value.raw='/tenants']",
+          message:
+            'POST /tenants is unauthenticated by spec (security: []); use raw fetch in auth/tenant.ts, never apiPost.',
+        },
+      ],
+    },
   },
   eslintConfigPrettier,
 ])

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -49,6 +49,13 @@ async function ensureKeyPair(): Promise<StoredKeyPair> {
 /**
  * Register a new tenant or reuse an existing tenant_id.
  * Returns the tenant_id that should be used as the `sub` claim.
+ *
+ * Tenant registration is only triggered from `initAuth()` behind the module-level
+ * `initPromise` singleton, so concurrent `initAuth()` calls cannot both pass the
+ * “no stored tenant” check and invoke `registerTenant()` twice.
+ *
+ * `registerTenant()` uses raw `fetch` for POST /tenants (OpenAPI `security: []`);
+ * it must never go through `apiPost`, which always attaches Bearer auth.
  */
 async function ensureTenantId(): Promise<string> {
   const existing = getStoredTenantId()
@@ -65,13 +72,15 @@ async function ensureTenantId(): Promise<string> {
  * Must be called once at app startup (before any authenticated API requests).
  * Idempotent — safe to call multiple times; registration only happens once.
  *
+ * Concurrent callers share one `initPromise`, which serializes the first-run path
+ * (including `ensureTenantId()`) so only one tenant registration runs per session.
+ *
  * Returns the tenant_id for informational use; callers do NOT need to store it.
  */
 export async function initAuth(): Promise<string> {
   if (!initPromise) {
     initPromise = (async () => {
-      // Kick off both in parallel — key pair generation is independent of
-      // tenant registration.
+      // Key pair work is independent of tenant registration; run both in parallel.
       const [tenantId] = await Promise.all([ensureTenantId(), ensureKeyPair()])
       return tenantId
     })()

--- a/src/auth/tenant.ts
+++ b/src/auth/tenant.ts
@@ -25,6 +25,10 @@ export function getStoredTenantId(): string | null {
 
 /**
  * Call POST /tenants and return the registration response.
+ *
+ * OpenAPI marks this operation as unauthenticated (`security: []`), so requests must
+ * use raw `fetch` here. Do not route through `apiPost`, which always adds Bearer auth.
+ *
  * Throws on non-2xx responses, including the full error body for debuggability.
  */
 export async function registerTenant(name: string): Promise<TenantRegistrationResponse> {

--- a/src/auth/tests/authService.test.ts
+++ b/src/auth/tests/authService.test.ts
@@ -65,6 +65,17 @@ describe('initAuth', () => {
 
     expect(mockRegister).toHaveBeenCalledOnce()
   })
+
+  it('registers tenant only once for concurrent initAuth calls', async () => {
+    mockGetStored.mockReturnValue(null)
+
+    const [t1, t2] = await Promise.all([initAuth(), initAuth()])
+
+    expect(t1).toBe('new-tenant-uuid')
+    expect(t2).toBe('new-tenant-uuid')
+    expect(mockRegister).toHaveBeenCalledOnce()
+    expect(mockStore).toHaveBeenCalledOnce()
+  })
 })
 
 describe('getBearerToken', () => {


### PR DESCRIPTION
The spec explicitly marks `POST /tenants` with `security: []` no authentication required. The implementation correctly uses a raw `fetch()` in `tenant.ts` rather than `apiPost`, so no Authorization header is sent. However, `authService.ensureTenantId()` reads `getStoredTenantId()`, and if two concurrent `initAuth()` calls both pass the `null` check before either one has written to localStorage via `storeTenantId()`, both will call `registerTenant()` simultaneously, creating two tenants for the same browser session.
 
### Tasks
 
- [x] In `authService.ensureTenantId()`: wrap the check-and-register sequence in the existing `initPromise` singleton confirm the single-promise guard already prevents concurrent registration, and add a comment explaining why.
- [x] Add a test: two concurrent calls to `initAuth()` (i.e. `await Promise.all([initAuth(), initAuth()])`) result in exactly one `registerTenant()` call.
- [x] Add a comment to `tenant.ts` and `authService.ts` documenting why `POST /tenants` must never go through `apiPost` (it is unauthenticated per spec `security: []`).
- [x] Add a lint rule or code-review checklist note: any call to the `/tenants` endpoint must use raw `fetch`, not `apiPost`.

Closes #42 