### PR TITLE
Add remove credential functionality to the UI

### DIFF
--- a/src/pages/CredentialDetailPage.tsx
+++ b/src/pages/CredentialDetailPage.tsx
@@ -218,7 +218,7 @@ function CredentialDetailContent({ credential }: { credential: CredentialRecord 
       >
         <ClaimsSection claims={credential.claims} />
       </section>
-      <div className="shrink-0 border-t border-slate-200 bg-[#E9ECEF] px-2 pb-1">
+      <div className="shrink-0 border-t border-slate-200 bg-[#E9ECEF] px-2 pb-2">
         <button
           type="button"
           onClick={() => navigate(credentialRemovePath(credential.id))}

--- a/src/pages/CredentialsPage.tsx
+++ b/src/pages/CredentialsPage.tsx
@@ -13,6 +13,7 @@ export function CredentialsPage() {
   const navigate = useNavigate()
   const { credentials, loading } = useCredentials()
 
+  // After delete we navigate here without refetching; filter session-removed IDs.
   const visibleCredentials = useMemo(
     () => credentials.filter((credential) => !isCredentialRemoved(credential.id)),
     [credentials]

--- a/src/pages/RemoveCredentialPage.tsx
+++ b/src/pages/RemoveCredentialPage.tsx
@@ -15,7 +15,7 @@ const NOT_LOST_ITEMS = [
 ] as const
 
 const RESTORE_ITEMS = [
-  'You will have to go the organization that issued you this credential and request it again',
+  'You will need to contact the organization that issued this credential and request it again.',
 ] as const
 
 function BulletList({ items }: { items: readonly string[] }) {
@@ -112,7 +112,7 @@ export function RemoveCredentialPage() {
             </div>
           </section>
 
-          <div className="shrink-0 border-t border-slate-200 bg-[#E9ECEF] px-2 pb-1">
+          <div className="shrink-0 border-t border-slate-200 bg-[#E9ECEF] px-2 pb-2">
             <button
               type="button"
               onClick={() => void handleRemoveFromWallet()}

--- a/src/pages/tests/RemoveCredentialPage.test.tsx
+++ b/src/pages/tests/RemoveCredentialPage.test.tsx
@@ -84,7 +84,7 @@ describe('RemoveCredentialPage', () => {
     ).toBeDefined()
     expect(
       screen.getByText(
-        'You will have to go the organization that issued you this credential and request it again'
+        'You will need to contact the organization that issued this credential and request it again.'
       )
     ).toBeDefined()
   })

--- a/src/utils/credentialDeleteErrors.ts
+++ b/src/utils/credentialDeleteErrors.ts
@@ -27,7 +27,7 @@ export function credentialDeleteErrorMessage(error: unknown): string {
     }
 
     if (error.status === 405 || error.status === 501) {
-      return 'Removing credentials is not available right now. Please try again later.'
+      return 'Failed to delete credential, please try again'
     }
 
     if (error.status === 408) {

--- a/src/utils/tests/credentialDeleteErrors.test.ts
+++ b/src/utils/tests/credentialDeleteErrors.test.ts
@@ -33,7 +33,7 @@ describe('credentialDeleteErrorMessage', () => {
     const error = new ApiError(501, 'DELETE /credentials/id failed with 501')
 
     expect(credentialDeleteErrorMessage(error)).toBe(
-      'Removing credentials is not available right now. Please try again later.'
+      'Failed to delete credential, please try again'
     )
   })
 


### PR DESCRIPTION
The backend now supports authenticated credential deletion through the `DELETE /credentials/{credential_id}` endpoint. The frontend needs a credential deletion flow that allows tenants to securely remove credentials they own from storage while properly handling authorization and missing credential errors.

---

## Tasks

- [x] Design credential deletion UI in credentials management page
- [x] Add delete action/button for credential items
- [x] Integrate authenticated `DELETE /credentials/{credential_id}` endpoint
- [x] Handle successful credential deletion and update UI state
- [x] Handle authorization and missing credential error responses
- [x] Add loading, disabled, and feedback states during deletion
- [x] Create frontend integration tests for credential deletion flow
- [x] Test successful deletion scenario
- [x] Test unauthorized deletion error scenario
- [x] Test missing credential error scenario

---

## Acceptance Criteria

- [x] Tenant can delete owned credentials from the UI
- [x] Deleted credential is removed from UI without page refresh
- [x] Unauthorized deletion attempts show an appropriate error message
- [x] Missing credential errors are handled correctly
- [x] Loading and feedback states work as expected
- [x] Frontend integration tests cover happy path and error scenarios


Figma design: https://www.figma.com/design/N6AMmhwM3CU1k1KToLQdIs/Untitled?node-id=188-9&p=f&t=KUmHAwyuD5XSuH3f-0

Closes #63 