### PR TITLE
Issuer display

### DIFF
--- a/e2e/fixtures/api-mock.ts
+++ b/e2e/fixtures/api-mock.ts
@@ -22,22 +22,26 @@ function buildStartIssuanceBody(profile: IssuanceStartProfile) {
   const base = {
     session_id: E2E_SESSION_ID,
     expires_at: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
-    issuer: {
-      credential_issuer: 'https://issuer.e2e.test',
-      display_name: 'E2E Issuer',
-      logo_uri: null,
-    },
+    credential_issuer: 'https://issuer.e2e.test',
+    issuer: [
+      {
+        name: 'E2E Issuer',
+        locale: 'en-US',
+      },
+    ],
     credential_types: [
       {
         credential_configuration_id: E2E_CREDENTIAL_CONFIGURATION_ID,
         format: 'dc+sd-jwt',
-        display: {
-          name: 'E2E PID',
-          description: 'Playwright fixture credential',
-          background_color: '#12107c',
-          text_color: '#ffffff',
-          logo: null,
-        },
+        display: [
+          {
+            name: 'E2E PID',
+            description: 'Playwright fixture credential',
+            background_color: '#12107c',
+            text_color: '#ffffff',
+            logo: null,
+          },
+        ],
       },
     ],
   }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -31,7 +31,6 @@ security:
 # Paths
 # ---------------------------------------------------------------------------
 paths:
-
   # -------------------------------------------------------------------------
   # 1. Tenant Registration
   # -------------------------------------------------------------------------
@@ -54,23 +53,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TenantRegistrationRequest"
+              $ref: '#/components/schemas/TenantRegistrationRequest'
             example:
               name: adorsys GmbH
       responses:
-        "201":
+        '201':
           description: Tenant successfully registered.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TenantRegistrationResponse"
+                $ref: '#/components/schemas/TenantRegistrationResponse'
               example:
                 tenant_id: f47ac10b-58cc-4372-a567-0e02b2c3d479
                 name: adorsys GmbH
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # -------------------------------------------------------------------------
   # 2. Start Issuance Session
@@ -92,29 +91,29 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/StartIssuanceRequest"
+              $ref: '#/components/schemas/StartIssuanceRequest'
             examples:
               offer_uri:
                 summary: Credential offer URI (credential_offer_uri)
                 value:
-                  offer: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123"
+                  offer: 'openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123'
               offer_inline:
                 summary: Inline credential offer URI (credential_offer)
                 value:
-                  offer: "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Fissuer.example.eu%22%7D"
+                  offer: 'openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Fissuer.example.eu%22%7D'
       responses:
-        "201":
+        '201':
           description: Session created. Returns session details and credential types for user consent.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StartIssuanceResponse"
+                $ref: '#/components/schemas/StartIssuanceResponse'
               examples:
                 authorization_code_flow:
                   summary: Authorization Code Flow
                   value:
                     session_id: ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni
-                    expires_at: "2026-04-08T14:35:00Z"
+                    expires_at: '2026-04-08T14:35:00Z'
                     issuer:
                       - name: Example EU Identity Authority
                         locale: en-US
@@ -127,8 +126,8 @@ paths:
                         display:
                           - name: EU Personal ID
                             description: Official EU personal identity document
-                            background_color: "#12107c"
-                            text_color: "#ffffff"
+                            background_color: '#12107c'
+                            text_color: '#ffffff'
                             logo:
                               uri: https://issuer.example.eu/assets/pid-logo.svg
                               alt_text: EU PID Logo
@@ -139,7 +138,7 @@ paths:
                   summary: Pre-Authorized Code Flow with Transaction Code
                   value:
                     session_id: ses_9aKpR1xWqNmLvYcZbTsE4dBfUhOo2Gj
-                    expires_at: "2026-04-08T14:35:00Z"
+                    expires_at: '2026-04-08T14:35:00Z'
                     issuer:
                       - name: Example EU Identity Authority
                         locale: en-US
@@ -149,36 +148,36 @@ paths:
                         display:
                           - name: EU Legal Person ID
                             description: Official EU legal entity identity credential
-                            background_color: "#1a4f2e"
-                            text_color: "#ffffff"
+                            background_color: '#1a4f2e'
+                            text_color: '#ffffff'
                     flow: pre_authorized_code
                     tx_code_required: true
                     tx_code:
                       input_mode: numeric
                       length: 6
                       description: Please provide the one-time code sent to your registered email address.
-        "400":
+        '400':
           description: Offer is missing, malformed, or unparsable.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: invalid_credential_offer
                 error_description: The credential offer URI could not be parsed.
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "502":
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
           description: Backend could not reach the issuer or authorization server metadata endpoint.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               examples:
                 issuer_metadata_failed:
                   value:
                     error: issuer_metadata_fetch_failed
-                    error_description: "Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer"
+                    error_description: 'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer'
                 auth_server_metadata_failed:
                   value:
                     error: auth_server_metadata_fetch_failed
@@ -210,13 +209,13 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: "#/components/parameters/SessionId"
+        - $ref: '#/components/parameters/SessionId'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ConsentRequest"
+              $ref: '#/components/schemas/ConsentRequest'
             examples:
               accept_all:
                 summary: User accepts all offered credentials
@@ -234,19 +233,19 @@ paths:
                 value:
                   accepted: false
       responses:
-        "200":
+        '200':
           description: Consent recorded. Inspect `next_action` to determine the frontend's next step.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ConsentResponse"
+                $ref: '#/components/schemas/ConsentResponse'
               examples:
                 redirect:
                   summary: Authorization code flow — redirect user to issuer AS
                   value:
                     session_id: ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni
                     next_action: redirect
-                    authorization_url: "https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&..."
+                    authorization_url: 'https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&...'
                 provide_tx_code:
                   summary: Pre-authorized code flow — transaction code required
                   value:
@@ -262,28 +261,28 @@ paths:
                   value:
                     session_id: ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni
                     next_action: rejected
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
           description: Session not found or has expired.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
-        "409":
+        '409':
           description: Session is not in `awaiting_consent` state.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: invalid_session_state
-                error_description: "Session is not awaiting consent (current state: processing)."
-        "500":
-          $ref: "#/components/responses/InternalServerError"
+                error_description: 'Session is not awaiting consent (current state: processing).'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # -------------------------------------------------------------------------
   # 4. SSE — Real-Time Session Updates
@@ -319,9 +318,9 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: "#/components/parameters/SessionId"
+        - $ref: '#/components/parameters/SessionId'
       responses:
-        "200":
+        '200':
           description: SSE stream opened successfully.
           headers:
             Cache-Control:
@@ -341,9 +340,9 @@ paths:
                   and their payloads are described in the `SseEvent` union
                   schema below.
                 oneOf:
-                  - $ref: "#/components/schemas/SseProcessingEvent"
-                  - $ref: "#/components/schemas/SseCompletedEvent"
-                  - $ref: "#/components/schemas/SseFailedEvent"
+                  - $ref: '#/components/schemas/SseProcessingEvent'
+                  - $ref: '#/components/schemas/SseCompletedEvent'
+                  - $ref: '#/components/schemas/SseFailedEvent'
               examples:
                 processing:
                   summary: processing event
@@ -360,14 +359,14 @@ paths:
                   value: |
                     event: failed
                     data: {"session_id":"ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni","state":"failed","error":"access_denied","error_description":"The user denied authorization at the issuer's authorization server.","step":"authorization"}
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
           description: Session not found or has expired.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
@@ -434,11 +433,11 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: |
             Callback accepted. The response body is empty; clients observe
             issuance progress through the session's SSE stream.
-        "400":
+        '400':
           description: |
             Missing or invalid `state` parameter. This includes unknown,
             expired, or non-`awaiting_authorization` sessions; these all return
@@ -446,7 +445,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: invalid_request
                 error_description: Missing required `state` query parameter.
@@ -473,17 +472,17 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: "#/components/parameters/SessionId"
+        - $ref: '#/components/parameters/SessionId'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TxCodeRequest"
+              $ref: '#/components/schemas/TxCodeRequest'
             example:
-              tx_code: "493821"
+              tx_code: '493821'
       responses:
-        "202":
+        '202':
           description: |
             Transaction code accepted. Token exchange and credential request
             have been started in the background. Listen on the SSE stream for
@@ -491,40 +490,40 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TxCodeResponse"
+                $ref: '#/components/schemas/TxCodeResponse'
               example:
                 session_id: ses_9aKpR1xWqNmLvYcZbTsE4dBfUhOo2Gj
-        "400":
-          description: "`tx_code` is missing, wrong length, or contains invalid characters."
+        '400':
+          description: '`tx_code` is missing, wrong length, or contains invalid characters.'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: invalid_tx_code
-                error_description: "Transaction code must be exactly 6 numeric digits."
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
+                error_description: 'Transaction code must be exactly 6 numeric digits.'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
           description: Session not found or has expired.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
-        "409":
+        '409':
           description: Session is not in `awaiting_tx_code` state.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: invalid_session_state
-                error_description: "Session is not awaiting a transaction code (current state: processing)."
-        "500":
-          $ref: "#/components/responses/InternalServerError"
+                error_description: 'Session is not awaiting a transaction code (current state: processing).'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # -------------------------------------------------------------------------
   # 7. Cancel Session
@@ -542,7 +541,7 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: "#/components/parameters/SessionId"
+        - $ref: '#/components/parameters/SessionId'
       requestBody:
         required: false
         content:
@@ -551,25 +550,25 @@ paths:
               type: object
               description: Empty body — no fields required.
       responses:
-        "204":
+        '204':
           description: Session successfully cancelled. No response body.
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
           description: Session not found or has already expired.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
-        "409":
+        '409':
           description: Session is already in a terminal state.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: invalid_session_state
                 error_description: Session is already in a terminal state and cannot be cancelled.
@@ -652,8 +651,8 @@ paths:
                     format: dc+sd-jwt
                     issuer: https://issuer.example.eu
                     status: active
-                    issued_at: "2026-04-08T14:35:00Z"
-                    expires_at: "2027-04-08T14:35:00Z"
+                    issued_at: '2026-04-08T14:35:00Z'
+                    expires_at: '2027-04-08T14:35:00Z'
                     claims:
                       given_name: Jane
                       family_name: Doe
@@ -690,8 +689,8 @@ paths:
                 format: dc+sd-jwt
                 issuer: https://issuer.example.eu
                 status: active
-                issued_at: "2026-04-08T14:35:00Z"
-                expires_at: "2027-04-08T14:35:00Z"
+                issued_at: '2026-04-08T14:35:00Z'
+                expires_at: '2027-04-08T14:35:00Z'
                 claims:
                   given_name: Jane
                   family_name: Doe
@@ -743,7 +742,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: credential_not_found
-                error_description: "Credential not found."
+                error_description: 'Credential not found.'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -751,7 +750,6 @@ paths:
 # Components
 # ---------------------------------------------------------------------------
 components:
-
   # -------------------------------------------------------------------------
   # Security Schemes
   # -------------------------------------------------------------------------
@@ -813,7 +811,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: '#/components/schemas/ErrorResponse'
           example:
             error: unauthorized
             error_description: Missing or invalid bearer token.
@@ -823,7 +821,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: '#/components/schemas/ErrorResponse'
           example:
             error: invalid_request
             error_description: Request body is missing required fields.
@@ -833,7 +831,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: '#/components/schemas/ErrorResponse'
           example:
             error: internal_error
             error_description: An unexpected error occurred. Please try again later.
@@ -842,7 +840,6 @@ components:
   # Schemas
   # -------------------------------------------------------------------------
   schemas:
-
     # -----------------------------------------------------------------------
     # Error
     # -----------------------------------------------------------------------
@@ -922,7 +919,7 @@ components:
             - A full `openid-credential-offer://` URI with `credential_offer`
               or `credential_offer_uri` as a query parameter.
             - The raw JSON of a credential offer object as a string.
-          example: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123"
+          example: 'openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123'
 
     StartIssuanceResponse:
       type: object
@@ -949,7 +946,7 @@ components:
             ISO 8601 session expiry timestamp (15 minutes from creation). The
             frontend MUST discard the session and inform the user if this time
             is reached.
-          example: "2026-04-08T14:35:00Z"
+          example: '2026-04-08T14:35:00Z'
         issuer:
           type: array
           description: |
@@ -958,7 +955,7 @@ components:
             Fallback: if no display metadata in issuer metadata, returns a single
             entry with `name` set to the credential_issuer URL.
           items:
-            $ref: "#/components/schemas/IssuerDisplay"
+            $ref: '#/components/schemas/IssuerDisplay'
         credential_types:
           type: array
           description: |
@@ -966,7 +963,7 @@ components:
             metadata from the issuer's `credential_configurations_supported`.
           minItems: 1
           items:
-            $ref: "#/components/schemas/CredentialTypeDisplay"
+            $ref: '#/components/schemas/CredentialTypeDisplay'
         flow:
           type: string
           enum:
@@ -986,8 +983,8 @@ components:
             frontend MUST use this metadata to render the transaction code
             input UI.
           oneOf:
-            - $ref: "#/components/schemas/TxCodeSpec"
-            - type: "null"
+            - $ref: '#/components/schemas/TxCodeSpec'
+            - type: 'null'
 
     IssuerDisplay:
       type: object
@@ -1005,7 +1002,7 @@ components:
           description: BCP47 language tag (e.g. "en-US").
           example: en-US
         logo:
-          $ref: "#/components/schemas/Logo"
+          $ref: '#/components/schemas/Logo'
 
     Logo:
       type: object
@@ -1048,7 +1045,7 @@ components:
           description: Array of display metadata for different locales.
           minItems: 1
           items:
-            $ref: "#/components/schemas/CredentialDisplay"
+            $ref: '#/components/schemas/CredentialDisplay'
 
     CredentialDisplay:
       type: object
@@ -1067,18 +1064,18 @@ components:
         background_color:
           type: string
           description: Background color for the credential card (CSS hex color).
-          pattern: "^#[0-9a-fA-F]{6}$"
-          example: "#12107c"
+          pattern: '^#[0-9a-fA-F]{6}$'
+          example: '#12107c'
         text_color:
           type: string
           description: Text color for the credential card (CSS hex color).
-          pattern: "^#[0-9a-fA-F]{6}$"
-          example: "#ffffff"
+          pattern: '^#[0-9a-fA-F]{6}$'
+          example: '#ffffff'
         logo:
           description: Logo image metadata. `null` if no logo is available.
           oneOf:
-            - $ref: "#/components/schemas/Logo"
-            - type: "null"
+            - $ref: '#/components/schemas/Logo'
+            - type: 'null'
 
     TxCodeSpec:
       type: object
@@ -1109,7 +1106,7 @@ components:
           oneOf:
             - type: integer
               minimum: 1
-            - type: "null"
+            - type: 'null'
           example: 6
         description:
           description: |
@@ -1120,7 +1117,7 @@ components:
           oneOf:
             - type: string
               maxLength: 300
-            - type: "null"
+            - type: 'null'
           example: Please provide the one-time code sent to your registered email address.
 
     # -----------------------------------------------------------------------
@@ -1181,7 +1178,7 @@ components:
             Present only when `next_action` is `"redirect"`. The full
             authorization URL (including PKCE `code_challenge`, or PAR
             `request_uri`) to open in the system browser.
-          example: "https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&..."
+          example: 'https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&...'
 
     # -----------------------------------------------------------------------
     # Transaction Code
@@ -1198,7 +1195,7 @@ components:
             - If `tx_code.input_mode` is `"numeric"`, MUST contain only ASCII
               digits (`[0-9]`).
             - If `tx_code.length` is set, length MUST exactly match that value.
-          example: "493821"
+          example: '493821'
 
     TxCodeResponse:
       type: object
@@ -1338,7 +1335,7 @@ components:
           description: Human-readable description of the failure. `null` if not available.
           oneOf:
             - type: string
-            - type: "null"
+            - type: 'null'
           example: The user denied authorization at the issuer's authorization server.
         step:
           type: string
@@ -1413,7 +1410,7 @@ components:
           type: string
           format: date-time
           description: ISO 8601 timestamp when the credential was issued.
-          example: "2026-04-08T14:35:00Z"
+          example: '2026-04-08T14:35:00Z'
         expires_at:
           description: |
             ISO 8601 timestamp when the credential expires. `null` if the
@@ -1422,7 +1419,7 @@ components:
             - type: string
               format: date-time
             - type: 'null'
-          example: "2027-04-08T14:35:00Z"
+          example: '2027-04-08T14:35:00Z'
         claims:
           type: object
           description: |

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -27,7 +27,14 @@ servers:
 security:
   - BearerAuth: []
 
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
 paths:
+
+  # -------------------------------------------------------------------------
+  # 1. Tenant Registration
+  # -------------------------------------------------------------------------
   /tenants:
     post:
       operationId: registerTenant
@@ -47,24 +54,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TenantRegistrationRequest'
+              $ref: "#/components/schemas/TenantRegistrationRequest"
             example:
               name: adorsys GmbH
       responses:
-        '201':
+        "201":
           description: Tenant successfully registered.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TenantRegistrationResponse'
+                $ref: "#/components/schemas/TenantRegistrationResponse"
               example:
                 tenant_id: f47ac10b-58cc-4372-a567-0e02b2c3d479
                 name: adorsys GmbH
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
+  # -------------------------------------------------------------------------
+  # 2. Start Issuance Session
+  # -------------------------------------------------------------------------
   /issuance/start:
     post:
       operationId: startIssuanceSession
@@ -82,44 +92,46 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/StartIssuanceRequest'
+              $ref: "#/components/schemas/StartIssuanceRequest"
             examples:
               offer_uri:
                 summary: Credential offer URI (credential_offer_uri)
                 value:
-                  offer: 'openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123'
+                  offer: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123"
               offer_inline:
                 summary: Inline credential offer URI (credential_offer)
                 value:
-                  offer: 'openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Fissuer.example.eu%22%7D'
+                  offer: "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Fissuer.example.eu%22%7D"
       responses:
-        '201':
+        "201":
           description: Session created. Returns session details and credential types for user consent.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StartIssuanceResponse'
+                $ref: "#/components/schemas/StartIssuanceResponse"
               examples:
                 authorization_code_flow:
                   summary: Authorization Code Flow
                   value:
                     session_id: ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni
-                    expires_at: '2026-04-08T14:35:00Z'
+                    expires_at: "2026-04-08T14:35:00Z"
                     issuer:
-                      credential_issuer: https://issuer.example.eu
-                      display_name: Example EU Identity Authority
-                      logo_uri: null
+                      - name: Example EU Identity Authority
+                        locale: en-US
+                        logo:
+                          uri: https://issuer.example.eu/assets/logo.svg
+                          alt_text: Example Issuer Logo
                     credential_types:
                       - credential_configuration_id: eu.europa.ec.eudi.pid.1
                         format: vc+sd-jwt
                         display:
-                          name: EU Personal ID
-                          description: Official EU personal identity document
-                          background_color: '#12107c'
-                          text_color: '#ffffff'
-                          logo:
-                            uri: https://issuer.example.eu/assets/pid-logo.svg
-                            alt_text: EU PID Logo
+                          - name: EU Personal ID
+                            description: Official EU personal identity document
+                            background_color: "#12107c"
+                            text_color: "#ffffff"
+                            logo:
+                              uri: https://issuer.example.eu/assets/pid-logo.svg
+                              alt_text: EU PID Logo
                     flow: authorization_code
                     tx_code_required: false
                     tx_code: null
@@ -127,53 +139,54 @@ paths:
                   summary: Pre-Authorized Code Flow with Transaction Code
                   value:
                     session_id: ses_9aKpR1xWqNmLvYcZbTsE4dBfUhOo2Gj
-                    expires_at: '2026-04-08T14:35:00Z'
+                    expires_at: "2026-04-08T14:35:00Z"
                     issuer:
-                      credential_issuer: https://issuer.example.eu
-                      display_name: Example EU Identity Authority
-                      logo_uri: null
+                      - name: Example EU Identity Authority
+                        locale: en-US
                     credential_types:
                       - credential_configuration_id: eu.europa.ec.eudi.lpid.1
                         format: vc+sd-jwt
                         display:
-                          name: EU Legal Person ID
-                          description: Official EU legal entity identity credential
-                          background_color: '#1a4f2e'
-                          text_color: '#ffffff'
-                          logo: null
+                          - name: EU Legal Person ID
+                            description: Official EU legal entity identity credential
+                            background_color: "#1a4f2e"
+                            text_color: "#ffffff"
                     flow: pre_authorized_code
                     tx_code_required: true
                     tx_code:
                       input_mode: numeric
                       length: 6
                       description: Please provide the one-time code sent to your registered email address.
-        '400':
+        "400":
           description: Offer is missing, malformed, or unparsable.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: invalid_credential_offer
                 error_description: The credential offer URI could not be parsed.
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '502':
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "502":
           description: Backend could not reach the issuer or authorization server metadata endpoint.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               examples:
                 issuer_metadata_failed:
                   value:
                     error: issuer_metadata_fetch_failed
-                    error_description: 'Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer'
+                    error_description: "Could not reach https://issuer.example.eu/.well-known/openid-credential-issuer"
                 auth_server_metadata_failed:
                   value:
                     error: auth_server_metadata_fetch_failed
                     error_description: Could not reach the authorization server metadata endpoint.
 
+  # -------------------------------------------------------------------------
+  # 3. Submit Consent
+  # -------------------------------------------------------------------------
   /issuance/{session_id}/consent:
     post:
       operationId: submitConsent
@@ -197,13 +210,13 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: '#/components/parameters/SessionId'
+        - $ref: "#/components/parameters/SessionId"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ConsentRequest'
+              $ref: "#/components/schemas/ConsentRequest"
             examples:
               accept_all:
                 summary: User accepts all offered credentials
@@ -221,19 +234,19 @@ paths:
                 value:
                   accepted: false
       responses:
-        '200':
+        "200":
           description: Consent recorded. Inspect `next_action` to determine the frontend's next step.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConsentResponse'
+                $ref: "#/components/schemas/ConsentResponse"
               examples:
                 redirect:
                   summary: Authorization code flow — redirect user to issuer AS
                   value:
                     session_id: ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni
                     next_action: redirect
-                    authorization_url: 'https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&...'
+                    authorization_url: "https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&..."
                 provide_tx_code:
                   summary: Pre-authorized code flow — transaction code required
                   value:
@@ -249,29 +262,32 @@ paths:
                   value:
                     session_id: ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni
                     next_action: rejected
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
           description: Session not found or has expired.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
-        '409':
+        "409":
           description: Session is not in `awaiting_consent` state.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: invalid_session_state
-                error_description: 'Session is not awaiting consent (current state: processing).'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+                error_description: "Session is not awaiting consent (current state: processing)."
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
+  # -------------------------------------------------------------------------
+  # 4. SSE — Real-Time Session Updates
+  # -------------------------------------------------------------------------
   /issuance/{session_id}/events:
     get:
       operationId: streamSessionEvents
@@ -303,9 +319,9 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: '#/components/parameters/SessionId'
+        - $ref: "#/components/parameters/SessionId"
       responses:
-        '200':
+        "200":
           description: SSE stream opened successfully.
           headers:
             Cache-Control:
@@ -325,9 +341,9 @@ paths:
                   and their payloads are described in the `SseEvent` union
                   schema below.
                 oneOf:
-                  - $ref: '#/components/schemas/SseProcessingEvent'
-                  - $ref: '#/components/schemas/SseCompletedEvent'
-                  - $ref: '#/components/schemas/SseFailedEvent'
+                  - $ref: "#/components/schemas/SseProcessingEvent"
+                  - $ref: "#/components/schemas/SseCompletedEvent"
+                  - $ref: "#/components/schemas/SseFailedEvent"
               examples:
                 processing:
                   summary: processing event
@@ -344,18 +360,21 @@ paths:
                   value: |
                     event: failed
                     data: {"session_id":"ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni","state":"failed","error":"access_denied","error_description":"The user denied authorization at the issuer's authorization server.","step":"authorization"}
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
           description: Session not found or has expired.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
 
+  # -------------------------------------------------------------------------
+  # 5. Authorization Callback
+  # -------------------------------------------------------------------------
   /issuance/callback:
     get:
       operationId: authorizationCallback
@@ -371,19 +390,17 @@ paths:
 
         **On success:**
         1. Validate `state` → recover session.
-        2. Exchange `code` for token (back-channel, with PKCE `code_verifier`).
-        3. Request credential(s) from the issuer's credential endpoint.
-        4. Store credential(s) and mark session `completed`.
-        5. Push `completed` SSE event.
-        6. Redirect to `<app_deep_link>?session_id=<session_id>&result=success`.
+        2. Mark the session `processing`.
+        3. Enqueue background issuance using the authorization code and PKCE
+           `code_verifier`.
+        4. Return `200 OK`. Completion or failure is reported through
+           the session's SSE stream.
 
         **On error (AS returns `error`):**
         1. Validate `state` → recover session.
-        2. Mark session `failed`; push `failed` SSE event (`step: "authorization"`).
-        3. Redirect to `<app_deep_link>?session_id=<session_id>&result=error&error=<error_code>`.
-
-        The `app_deep_link` scheme is configured per deployment and is out of
-        scope for this specification.
+        2. Push a `failed` SSE event (`step: "authorization"`).
+        3. Remove the session.
+        4. Return `200 OK`.
       security: [] # Authenticated via `state` parameter — no bearer token
       tags:
         - Issuance
@@ -417,41 +434,26 @@ paths:
           schema:
             type: string
       responses:
-        '302':
+        "200":
           description: |
-            Redirect to the frontend's registered deep link URI.
-            - Success: `<app_deep_link>?session_id=<id>&result=success`
-            - Error:   `<app_deep_link>?session_id=<id>&result=error&error=<code>`
-          headers:
-            Location:
-              required: true
-              schema:
-                type: string
-                format: uri
-              examples:
-                success:
-                  value: 'wallet://issuance/callback?session_id=ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni&result=success'
-                error:
-                  value: 'wallet://issuance/callback?session_id=ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni&result=error&error=access_denied'
-        '400':
-          description: Missing or invalid `state` parameter.
+            Callback accepted. The response body is empty; clients observe
+            issuance progress through the session's SSE stream.
+        "400":
+          description: |
+            Missing or invalid `state` parameter. This includes unknown,
+            expired, or non-`awaiting_authorization` sessions; these all return
+            `400` to avoid leaking session existence to unauthenticated callers.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: invalid_request
                 error_description: Missing required `state` query parameter.
-        '404':
-          description: No active session found matching the given `state`.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error: session_not_found
-                error_description: No active session found for the given state value.
 
+  # -------------------------------------------------------------------------
+  # 6. Submit Transaction Code
+  # -------------------------------------------------------------------------
   /issuance/{session_id}/tx-code:
     post:
       operationId: submitTransactionCode
@@ -471,17 +473,17 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: '#/components/parameters/SessionId'
+        - $ref: "#/components/parameters/SessionId"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TxCodeRequest'
+              $ref: "#/components/schemas/TxCodeRequest"
             example:
-              tx_code: '493821'
+              tx_code: "493821"
       responses:
-        '202':
+        "202":
           description: |
             Transaction code accepted. Token exchange and credential request
             have been started in the background. Listen on the SSE stream for
@@ -489,41 +491,44 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TxCodeResponse'
+                $ref: "#/components/schemas/TxCodeResponse"
               example:
                 session_id: ses_9aKpR1xWqNmLvYcZbTsE4dBfUhOo2Gj
-        '400':
-          description: '`tx_code` is missing, wrong length, or contains invalid characters.'
+        "400":
+          description: "`tx_code` is missing, wrong length, or contains invalid characters."
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: invalid_tx_code
-                error_description: 'Transaction code must be exactly 6 numeric digits.'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
+                error_description: "Transaction code must be exactly 6 numeric digits."
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
           description: Session not found or has expired.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
-        '409':
+        "409":
           description: Session is not in `awaiting_tx_code` state.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: invalid_session_state
-                error_description: 'Session is not awaiting a transaction code (current state: processing).'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+                error_description: "Session is not awaiting a transaction code (current state: processing)."
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
+  # -------------------------------------------------------------------------
+  # 7. Cancel Session
+  # -------------------------------------------------------------------------
   /issuance/{session_id}/cancel:
     post:
       operationId: cancelSession
@@ -537,7 +542,7 @@ paths:
       tags:
         - Issuance
       parameters:
-        - $ref: '#/components/parameters/SessionId'
+        - $ref: "#/components/parameters/SessionId"
       requestBody:
         required: false
         content:
@@ -546,31 +551,34 @@ paths:
               type: object
               description: Empty body — no fields required.
       responses:
-        '204':
+        "204":
           description: Session successfully cancelled. No response body.
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
           description: Session not found or has already expired.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: session_not_found
                 error_description: No active session found for the given session_id.
-        '409':
+        "409":
           description: Session is already in a terminal state.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: invalid_session_state
                 error_description: Session is already in a terminal state and cannot be cancelled.
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  # -------------------------------------------------------------------------
+  # 8. List Credentials
+  # -------------------------------------------------------------------------
   /credentials:
     get:
       operationId: listCredentials
@@ -644,8 +652,8 @@ paths:
                     format: dc+sd-jwt
                     issuer: https://issuer.example.eu
                     status: active
-                    issued_at: '2026-04-08T14:35:00Z'
-                    expires_at: '2027-04-08T14:35:00Z'
+                    issued_at: "2026-04-08T14:35:00Z"
+                    expires_at: "2027-04-08T14:35:00Z"
                     claims:
                       given_name: Jane
                       family_name: Doe
@@ -654,6 +662,9 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  # -------------------------------------------------------------------------
+  # 9. Get Single Credential
+  # -------------------------------------------------------------------------
   /credentials/{id}:
     get:
       operationId: getCredential
@@ -679,8 +690,8 @@ paths:
                 format: dc+sd-jwt
                 issuer: https://issuer.example.eu
                 status: active
-                issued_at: '2026-04-08T14:35:00Z'
-                expires_at: '2027-04-08T14:35:00Z'
+                issued_at: "2026-04-08T14:35:00Z"
+                expires_at: "2027-04-08T14:35:00Z"
                 claims:
                   given_name: Jane
                   family_name: Doe
@@ -698,20 +709,21 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+    # -----------------------------------------------------------------------
+    # 10. Delete Credential
+    # -----------------------------------------------------------------------
     delete:
       operationId: deleteCredential
-      summary: Delete a credential from the wallet
+      summary: Delete a credential owned by the authenticated tenant
       description: |
-        Permanently removes a single credential identified by its internal
-        wallet UUID from the authenticated tenant's storage.
+        Permanently removes the credential identified by `id` from the wallet.
 
-        The backend MUST verify that the credential belongs to the
-        authenticated tenant before deleting it. A tenant cannot delete
-        credentials owned by another tenant — attempting to do so returns
-        `403 Forbidden`.
-
-        This operation is irreversible. The credential cannot be recovered
-        after deletion; the user must re-issue it if needed.
+        Ownership is verified by scoping the deletion to both the `id` path
+        parameter and the `tenant_id` extracted from the bearer JWT (`sub`
+        claim). If the credential does not exist **or** belongs to a different
+        tenant the response is `404 Not Found`; the two cases are intentionally
+        indistinguishable to avoid leaking information about other tenants'
+        credentials.
       tags:
         - Credentials
       parameters:
@@ -721,28 +733,28 @@ paths:
           description: Credential successfully deleted. No response body.
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '403':
-          description: The authenticated tenant does not own this credential.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error: forbidden
-                error_description: You do not have permission to delete this credential.
         '404':
-          description: No credential with that ID exists for the authenticated tenant.
+          description: |
+            No credential with that ID exists for the authenticated tenant, or
+            the credential belongs to a different tenant.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: credential_not_found
-                error_description: No credential with that ID exists for the authenticated tenant.
+                error_description: "Credential not found."
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+# ---------------------------------------------------------------------------
+# Components
+# ---------------------------------------------------------------------------
 components:
+
+  # -------------------------------------------------------------------------
+  # Security Schemes
+  # -------------------------------------------------------------------------
   securitySchemes:
     BearerAuth:
       type: http
@@ -766,6 +778,9 @@ components:
         in the token, checks `exp`, and verifies that `sub` matches the
         resource being accessed.
 
+  # -------------------------------------------------------------------------
+  # Reusable Parameters
+  # -------------------------------------------------------------------------
   parameters:
     SessionId:
       name: session_id
@@ -789,13 +804,16 @@ components:
         format: uuid
         example: c3d4e5f6-7890-abcd-ef12-3456789abcde
 
+  # -------------------------------------------------------------------------
+  # Reusable Responses
+  # -------------------------------------------------------------------------
   responses:
     Unauthorized:
       description: Missing or invalid bearer token.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: "#/components/schemas/ErrorResponse"
           example:
             error: unauthorized
             error_description: Missing or invalid bearer token.
@@ -805,7 +823,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: "#/components/schemas/ErrorResponse"
           example:
             error: invalid_request
             error_description: Request body is missing required fields.
@@ -815,12 +833,19 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: "#/components/schemas/ErrorResponse"
           example:
             error: internal_error
             error_description: An unexpected error occurred. Please try again later.
 
+  # -------------------------------------------------------------------------
+  # Schemas
+  # -------------------------------------------------------------------------
   schemas:
+
+    # -----------------------------------------------------------------------
+    # Error
+    # -----------------------------------------------------------------------
     ErrorResponse:
       type: object
       description: |
@@ -842,14 +867,15 @@ components:
             - auth_server_metadata_fetch_failed
             - invalid_request
             - unauthorized
-            - forbidden
-            - credential_not_found
             - internal_error
         error_description:
           type: string
           description: Human-readable explanation of what went wrong.
           example: The credential offer URI could not be parsed.
 
+    # -----------------------------------------------------------------------
+    # Tenant Registration
+    # -----------------------------------------------------------------------
     TenantRegistrationRequest:
       type: object
       required:
@@ -881,6 +907,9 @@ components:
           description: Echo of the registered name.
           example: adorsys GmbH
 
+    # -----------------------------------------------------------------------
+    # Start Issuance
+    # -----------------------------------------------------------------------
     StartIssuanceRequest:
       type: object
       required:
@@ -893,7 +922,7 @@ components:
             - A full `openid-credential-offer://` URI with `credential_offer`
               or `credential_offer_uri` as a query parameter.
             - The raw JSON of a credential offer object as a string.
-          example: 'openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123'
+          example: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.eu%2Foffer%2Fabc123"
 
     StartIssuanceResponse:
       type: object
@@ -920,9 +949,16 @@ components:
             ISO 8601 session expiry timestamp (15 minutes from creation). The
             frontend MUST discard the session and inform the user if this time
             is reached.
-          example: '2026-04-08T14:35:00Z'
+          example: "2026-04-08T14:35:00Z"
         issuer:
-          $ref: '#/components/schemas/IssuerSummary'
+          type: array
+          description: |
+            Display properties for the Credential Issuer per OpenID4VCI spec.
+            Contains one or more display objects for different locales.
+            Fallback: if no display metadata in issuer metadata, returns a single
+            entry with `name` set to the credential_issuer URL.
+          items:
+            $ref: "#/components/schemas/IssuerDisplay"
         credential_types:
           type: array
           description: |
@@ -930,7 +966,7 @@ components:
             metadata from the issuer's `credential_configurations_supported`.
           minItems: 1
           items:
-            $ref: '#/components/schemas/CredentialTypeDisplay'
+            $ref: "#/components/schemas/CredentialTypeDisplay"
         flow:
           type: string
           enum:
@@ -950,39 +986,42 @@ components:
             frontend MUST use this metadata to render the transaction code
             input UI.
           oneOf:
-            - $ref: '#/components/schemas/TxCodeSpec'
-            - type: 'null'
+            - $ref: "#/components/schemas/TxCodeSpec"
+            - type: "null"
 
-    IssuerSummary:
+    IssuerDisplay:
+      type: object
+      description: |
+        Display properties for a Credential Issuer per OpenID4VCI spec §12.2.4.
+        When issuer metadata lacks display info, a fallback object is created
+        with `name` set to the credential_issuer URL.
+      properties:
+        name:
+          type: string
+          description: Human-readable display name of the Credential Issuer.
+          example: Example EU Identity Authority
+        locale:
+          type: string
+          description: BCP47 language tag (e.g. "en-US").
+          example: en-US
+        logo:
+          $ref: "#/components/schemas/Logo"
+
+    Logo:
       type: object
       required:
-        - credential_issuer
-        - display_name
-        - logo_uri
-      description: Resolved issuer metadata summary returned by `/start`.
+        - uri
+      description: Logo information for display objects.
       properties:
-        credential_issuer:
+        uri:
           type: string
           format: uri
-          description: Issuer identifier URL.
-          example: https://issuer.example.eu
-        display_name:
-          description: |
-            Human-readable issuer name from issuer metadata `display[0].name`.
-            `null` if not present in the issuer metadata.
-          oneOf:
-            - type: string
-            - type: 'null'
-          example: Example EU Identity Authority
-        logo_uri:
-          description: |
-            Issuer logo URI from issuer metadata `display[0].logo.uri`.
-            `null` if not present.
-          oneOf:
-            - type: string
-              format: uri
-            - type: 'null'
-          example: null
+          description: URI where the logo image can be obtained.
+          example: https://issuer.example.eu/assets/logo.svg
+        alt_text:
+          type: string
+          description: Alternative text for accessibility.
+          example: EU Issuer Logo
 
     CredentialTypeDisplay:
       type: object
@@ -992,9 +1031,9 @@ components:
         - display
       description: |
         A single credential configuration being offered, enriched with display
-        metadata sourced from `credential_configurations_supported[id].display[0]`
-        for the best-matching locale (fallback to first entry if no locale
-        match).
+        metadata sourced from `credential_configurations_supported[id].display`
+        for all available locales (fallback to single entry with configuration
+        ID as name if no display metadata exists).
       properties:
         credential_configuration_id:
           type: string
@@ -1005,7 +1044,11 @@ components:
           description: Credential format (e.g. `vc+sd-jwt`, `mso_mdoc`).
           example: vc+sd-jwt
         display:
-          $ref: '#/components/schemas/CredentialDisplay'
+          type: array
+          description: Array of display metadata for different locales.
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CredentialDisplay"
 
     CredentialDisplay:
       type: object
@@ -1024,34 +1067,18 @@ components:
         background_color:
           type: string
           description: Background color for the credential card (CSS hex color).
-          pattern: '^#[0-9a-fA-F]{6}$'
-          example: '#12107c'
+          pattern: "^#[0-9a-fA-F]{6}$"
+          example: "#12107c"
         text_color:
           type: string
           description: Text color for the credential card (CSS hex color).
-          pattern: '^#[0-9a-fA-F]{6}$'
-          example: '#ffffff'
+          pattern: "^#[0-9a-fA-F]{6}$"
+          example: "#ffffff"
         logo:
           description: Logo image metadata. `null` if no logo is available.
           oneOf:
-            - $ref: '#/components/schemas/CredentialLogo'
-            - type: 'null'
-
-    CredentialLogo:
-      type: object
-      required:
-        - uri
-      description: Logo image for a credential type.
-      properties:
-        uri:
-          type: string
-          format: uri
-          description: URI of the logo image.
-          example: https://issuer.example.eu/assets/pid-logo.svg
-        alt_text:
-          type: string
-          description: Accessibility alt text for the logo image.
-          example: EU PID Logo
+            - $ref: "#/components/schemas/Logo"
+            - type: "null"
 
     TxCodeSpec:
       type: object
@@ -1082,7 +1109,7 @@ components:
           oneOf:
             - type: integer
               minimum: 1
-            - type: 'null'
+            - type: "null"
           example: 6
         description:
           description: |
@@ -1093,9 +1120,12 @@ components:
           oneOf:
             - type: string
               maxLength: 300
-            - type: 'null'
+            - type: "null"
           example: Please provide the one-time code sent to your registered email address.
 
+    # -----------------------------------------------------------------------
+    # Consent
+    # -----------------------------------------------------------------------
     ConsentRequest:
       type: object
       required:
@@ -1151,8 +1181,11 @@ components:
             Present only when `next_action` is `"redirect"`. The full
             authorization URL (including PKCE `code_challenge`, or PAR
             `request_uri`) to open in the system browser.
-          example: 'https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&...'
+          example: "https://as.issuer.example.eu/authorize?response_type=code&client_id=wallet.example.eu&..."
 
+    # -----------------------------------------------------------------------
+    # Transaction Code
+    # -----------------------------------------------------------------------
     TxCodeRequest:
       type: object
       required:
@@ -1165,7 +1198,7 @@ components:
             - If `tx_code.input_mode` is `"numeric"`, MUST contain only ASCII
               digits (`[0-9]`).
             - If `tx_code.length` is set, length MUST exactly match that value.
-          example: '493821'
+          example: "493821"
 
     TxCodeResponse:
       type: object
@@ -1177,6 +1210,9 @@ components:
           description: Session identifier (echo).
           example: ses_9aKpR1xWqNmLvYcZbTsE4dBfUhOo2Gj
 
+    # -----------------------------------------------------------------------
+    # SSE Event Payloads
+    # -----------------------------------------------------------------------
     SseProcessingEvent:
       type: object
       description: |
@@ -1302,7 +1338,7 @@ components:
           description: Human-readable description of the failure. `null` if not available.
           oneOf:
             - type: string
-            - type: 'null'
+            - type: "null"
           example: The user denied authorization at the issuer's authorization server.
         step:
           type: string
@@ -1377,7 +1413,7 @@ components:
           type: string
           format: date-time
           description: ISO 8601 timestamp when the credential was issued.
-          example: '2026-04-08T14:35:00Z'
+          example: "2026-04-08T14:35:00Z"
         expires_at:
           description: |
             ISO 8601 timestamp when the credential expires. `null` if the
@@ -1386,7 +1422,7 @@ components:
             - type: string
               format: date-time
             - type: 'null'
-          example: '2027-04-08T14:35:00Z'
+          example: "2027-04-08T14:35:00Z"
         claims:
           type: object
           description: |
@@ -1408,6 +1444,9 @@ components:
           items:
             $ref: '#/components/schemas/CredentialRecord'
 
+# ---------------------------------------------------------------------------
+# Tags
+# ---------------------------------------------------------------------------
 tags:
   - name: Tenants
     description: Tenant registration and management.
@@ -1418,5 +1457,5 @@ tags:
       Code and Pre-Authorized Code grant types.
   - name: Credentials
     description: |
-      Credential retrieval and management. Read and delete access to verifiable
-      credentials stored in the wallet after a successful issuance flow.
+      Credential retrieval. Read-only access to verifiable credentials
+      stored in the wallet after a successful issuance flow.

--- a/src/api/tests/issuance.test.ts
+++ b/src/api/tests/issuance.test.ts
@@ -56,7 +56,7 @@ const minimalSession: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'vc+sd-jwt',
+      format: 'dc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',

--- a/src/api/tests/issuance.test.ts
+++ b/src/api/tests/issuance.test.ts
@@ -56,7 +56,7 @@ const minimalSession: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'dc+sd-jwt',
+      format: 'vc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',

--- a/src/api/tests/issuance.test.ts
+++ b/src/api/tests/issuance.test.ts
@@ -48,22 +48,26 @@ function mockResponse(
 const minimalSession: StartIssuanceResponse = {
   session_id: 'ses_abc123',
   expires_at: '2026-04-08T14:35:00Z',
-  issuer: {
-    credential_issuer: 'https://issuer.example.eu',
-    display_name: 'Example Issuer',
-    logo_uri: null,
-  },
+  credential_issuer: 'https://issuer.example.eu',
+  issuer: [
+    {
+      name: 'Example Issuer',
+      locale: 'en-US',
+    },
+  ],
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
       format: 'dc+sd-jwt',
-      display: {
-        name: 'EU Personal ID',
-        description: 'Official EU personal identity document',
-        background_color: '#12107c',
-        text_color: '#ffffff',
-        logo: null,
-      },
+      display: [
+        {
+          name: 'EU Personal ID',
+          description: 'Official EU personal identity document',
+          background_color: '#12107c',
+          text_color: '#ffffff',
+          logo: null,
+        },
+      ],
     },
   ],
   flow: 'authorization_code',

--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -16,22 +16,31 @@ import type { CredentialRecord } from '../../types/credential'
 const validStartIssuanceResponse: StartIssuanceResponse = {
   session_id: 'ses_abc123',
   expires_at: '2026-04-08T14:35:00Z',
-  issuer: {
-    credential_issuer: 'https://issuer.example.eu',
-    display_name: 'Example Issuer',
-    logo_uri: null,
-  },
+  credential_issuer: 'https://issuer.example.eu',
+  issuer: [
+    {
+      name: 'Example Issuer',
+      locale: 'en-US',
+      logo: {
+        uri: 'https://issuer.example.eu/logo.png',
+        alt_text: 'Issuer logo',
+      },
+      description: 'An example issuer',
+    },
+  ],
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
       format: 'dc+sd-jwt',
-      display: {
-        name: 'EU Personal ID',
-        description: 'Official EU personal identity document',
-        background_color: '#12107c',
-        text_color: '#ffffff',
-        logo: null,
-      },
+      display: [
+        {
+          name: 'EU Personal ID',
+          description: 'Official EU personal identity document',
+          background_color: '#12107c',
+          text_color: '#ffffff',
+          logo: null,
+        },
+      ],
     },
   ],
   flow: 'authorization_code',
@@ -67,16 +76,47 @@ describe('validateStartIssuanceResponse', () => {
     expect(result.tx_code?.length).toBe(6)
   })
 
-  it('accepts null logo_uri and null display_name on issuer', () => {
+  it('accepts empty display array on issuer', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      issuer: [],
+    }
+    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+  })
+
+  it('accepts display entry without optional fields', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      issuer: [{ name: 'Minimal Issuer' }],
+    }
+    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+  })
+
+  it('accepts display entry with only logo', () => {
+    const input = {
+      ...validStartIssuanceResponse,
+      issuer: [
+        {
+          logo: {
+            uri: 'https://issuer.example.eu/logo.png',
+            alt_text: 'Issuer logo',
+          },
+        },
+      ],
+    }
+    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+  })
+
+  it('throws ContractError when issuer is not an array', () => {
     const input = {
       ...validStartIssuanceResponse,
       issuer: {
         credential_issuer: 'https://issuer.example.eu',
-        display_name: null,
+        display_name: 'Example Issuer',
         logo_uri: null,
       },
     }
-    expect(() => validateStartIssuanceResponse(input)).not.toThrow()
+    expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
   })
 
   it('throws ContractError when session_id is missing', () => {
@@ -137,17 +177,6 @@ describe('validateStartIssuanceResponse', () => {
     expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
   })
 
-  it('throws ContractError when issuer.display_name is neither string nor null', () => {
-    const input = {
-      ...validStartIssuanceResponse,
-      issuer: {
-        ...validStartIssuanceResponse.issuer,
-        display_name: 42,
-      },
-    }
-    expect(() => validateStartIssuanceResponse(input)).toThrow(ContractError)
-  })
-
   it('throws ContractError when tx_code.length is not number|null', () => {
     const input = {
       ...validStartIssuanceResponse,
@@ -180,7 +209,7 @@ describe('validateStartIssuanceResponse', () => {
       credential_types: [
         {
           ...validStartIssuanceResponse.credential_types[0],
-          display: { name: 'Only Name' },
+          display: [{ name: 'Only Name' }],
         },
       ],
     }
@@ -193,10 +222,12 @@ describe('validateStartIssuanceResponse', () => {
       credential_types: [
         {
           ...validStartIssuanceResponse.credential_types[0],
-          display: {
-            name: 'EU Personal ID',
-            logo: { uri: 'https://issuer.example.eu/logo.svg' },
-          },
+          display: [
+            {
+              name: 'EU Personal ID',
+              logo: { uri: 'https://issuer.example.eu/logo.svg' },
+            },
+          ],
         },
       ],
     }
@@ -209,13 +240,15 @@ describe('validateStartIssuanceResponse', () => {
       credential_types: [
         {
           ...validStartIssuanceResponse.credential_types[0],
-          display: {
-            name: 'EU Personal ID',
-            logo: {
-              uri: 'https://issuer.example.eu/logo.svg',
-              alt_text: 'Issuer mark',
+          display: [
+            {
+              name: 'EU Personal ID',
+              logo: {
+                uri: 'https://issuer.example.eu/logo.svg',
+                alt_text: 'Issuer mark',
+              },
             },
-          },
+          ],
         },
       ],
     }
@@ -241,6 +274,12 @@ describe('validateCredentialRecord', () => {
     const input = { ...validCredentialRecord, expires_at: null }
     const result = validateCredentialRecord(input)
     expect(result.expires_at).toBeNull()
+  })
+
+  it('accepts a record with undefined expires_at (field omitted)', () => {
+    const { expires_at: _, ...rest } = validCredentialRecord
+    const result = validateCredentialRecord(rest)
+    expect(result.expires_at).toBeUndefined()
   })
 
   it('accepts a record with additional claim properties', () => {
@@ -272,9 +311,10 @@ describe('validateCredentialRecord', () => {
     expect(() => validateCredentialRecord(input)).toThrow(ContractError)
   })
 
-  it('throws ContractError when claims is null', () => {
+  it('accepts null claims and converts to empty object', () => {
     const input = { ...validCredentialRecord, claims: null }
-    expect(() => validateCredentialRecord(input)).toThrow(ContractError)
+    const result = validateCredentialRecord(input)
+    expect(result.claims).toEqual({})
   })
 
   it('throws ContractError when the response is not an object', () => {

--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -19,7 +19,7 @@ const validStartIssuanceResponse: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'dc+sd-jwt',
+      format: 'vc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',
@@ -114,7 +114,7 @@ describe('validateStartIssuanceResponse', () => {
       credential_types: [
         {
           credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-          format: 'dc+sd-jwt',
+          format: 'vc+sd-jwt',
           display: { description: 'no name here' },
         },
       ],

--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -277,7 +277,8 @@ describe('validateCredentialRecord', () => {
   })
 
   it('accepts a record with undefined expires_at (field omitted)', () => {
-    const { expires_at: _, ...rest } = validCredentialRecord
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { expires_at: _expiresAt, ...rest } = validCredentialRecord
     const result = validateCredentialRecord(rest)
     expect(result.expires_at).toBeUndefined()
   })

--- a/src/api/tests/validation.test.ts
+++ b/src/api/tests/validation.test.ts
@@ -19,7 +19,7 @@ const validStartIssuanceResponse: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'vc+sd-jwt',
+      format: 'dc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',
@@ -114,7 +114,7 @@ describe('validateStartIssuanceResponse', () => {
       credential_types: [
         {
           credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { description: 'no name here' },
         },
       ],

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -206,7 +206,8 @@ function validateCredentialTypeDisplay(
   const ctx = `CredentialTypeDisplay[${index}]`
   const obj = requireObject(ctx, 'credential_type', raw)
   const rawDisplayArray = requireArray(ctx, 'display', obj.display)
-  if (rawDisplayArray.length === 0) throw new ContractError(ctx, 'display', rawDisplayArray)
+  if (rawDisplayArray.length === 0)
+    throw new ContractError(ctx, 'display', rawDisplayArray)
   return {
     credential_configuration_id: requireString(
       ctx,
@@ -241,9 +242,10 @@ export function validateStartIssuanceResponse(raw: unknown): StartIssuanceRespon
   const session_id = requireString(ctx, 'session_id', obj.session_id)
   const expires_at = requireDateTimeString(ctx, 'expires_at', obj.expires_at)
   // credential_issuer is optional - not present in current backend response
-  const credential_issuer = obj.credential_issuer !== undefined
-    ? requireString(ctx, 'credential_issuer', obj.credential_issuer)
-    : undefined
+  const credential_issuer =
+    obj.credential_issuer !== undefined
+      ? requireString(ctx, 'credential_issuer', obj.credential_issuer)
+      : undefined
   const issuer = validateIssuerSummary(obj.issuer)
 
   const rawTypes = requireArray(ctx, 'credential_types', obj.credential_types)
@@ -525,4 +527,3 @@ export function parseValidatedSsePayload(
       return null
   }
 }
-

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -31,6 +31,7 @@ import type {
   CredentialDisplay,
   CredentialTypeDisplay,
   IssuanceFlow,
+  IssuerDisplayEntry,
   IssuerSummary,
   SseCompletedEvent,
   SseEvent,
@@ -70,6 +71,16 @@ function requireStringOrNull(ctx: string, field: string, value: unknown): string
   if (value !== null && typeof value !== 'string')
     throw new ContractError(ctx, field, value)
   return value as string | null
+}
+
+function requireOptionalStringOrNull(
+  ctx: string,
+  field: string,
+  value: unknown
+): string | null | undefined {
+  if (value !== undefined && value !== null && typeof value !== 'string')
+    throw new ContractError(ctx, field, value)
+  return value as string | null | undefined
 }
 
 function requireBoolean(ctx: string, field: string, value: unknown): boolean {
@@ -120,18 +131,43 @@ const CONSENT_NEXT_ACTIONS: ConsentNextAction[] = [
   'rejected',
 ]
 
-function validateIssuerSummary(raw: unknown): IssuerSummary {
-  const ctx = 'IssuerSummary'
-  const obj = requireObject(ctx, 'issuer', raw)
-  return {
-    credential_issuer: requireString(ctx, 'credential_issuer', obj.credential_issuer),
-    display_name: requireStringOrNull(ctx, 'display_name', obj.display_name),
-    logo_uri: requireStringOrNull(ctx, 'logo_uri', obj.logo_uri),
+function validateIssuerDisplayEntry(raw: unknown, index: number): IssuerDisplayEntry {
+  const ctx = `IssuerDisplayEntry[${index}]`
+  const obj = requireObject(ctx, 'display entry', raw)
+
+  const entry: IssuerDisplayEntry = {}
+
+  if (obj.name !== undefined) {
+    entry.name = requireString(ctx, 'name', obj.name)
   }
+  if (obj.locale !== undefined) {
+    entry.locale = requireString(ctx, 'locale', obj.locale)
+  }
+  if (obj.description !== undefined) {
+    entry.description = requireString(ctx, 'description', obj.description)
+  }
+  if (obj.logo !== undefined && obj.logo !== null) {
+    const logoObj = requireObject(ctx, 'logo', obj.logo)
+    entry.logo = {
+      uri: requireString(ctx, 'logo.uri', logoObj.uri),
+    }
+    if (logoObj.alt_text !== undefined) {
+      entry.logo.alt_text = requireString(ctx, 'logo.alt_text', logoObj.alt_text)
+    }
+  }
+
+  return entry
 }
 
-function validateCredentialDisplay(raw: unknown): CredentialDisplay {
-  const ctx = 'CredentialDisplay'
+function validateIssuerSummary(raw: unknown): IssuerSummary {
+  const ctx = 'IssuerSummary'
+  // Per OpenAPI spec, issuer is directly the display array
+  const displayArray = requireArray(ctx, 'issuer', raw)
+  return displayArray.map((entry, index) => validateIssuerDisplayEntry(entry, index))
+}
+
+function validateCredentialDisplay(raw: unknown, index: number): CredentialDisplay {
+  const ctx = `CredentialDisplay[${index}]`
   const obj = requireObject(ctx, 'display', raw)
 
   const name = requireString(ctx, 'name', obj.name)
@@ -169,6 +205,8 @@ function validateCredentialTypeDisplay(
 ): CredentialTypeDisplay {
   const ctx = `CredentialTypeDisplay[${index}]`
   const obj = requireObject(ctx, 'credential_type', raw)
+  const rawDisplayArray = requireArray(ctx, 'display', obj.display)
+  if (rawDisplayArray.length === 0) throw new ContractError(ctx, 'display', rawDisplayArray)
   return {
     credential_configuration_id: requireString(
       ctx,
@@ -176,7 +214,7 @@ function validateCredentialTypeDisplay(
       obj.credential_configuration_id
     ),
     format: requireString(ctx, 'format', obj.format),
-    display: validateCredentialDisplay(obj.display),
+    display: rawDisplayArray.map((entry, i) => validateCredentialDisplay(entry, i)),
   }
 }
 
@@ -202,6 +240,10 @@ export function validateStartIssuanceResponse(raw: unknown): StartIssuanceRespon
 
   const session_id = requireString(ctx, 'session_id', obj.session_id)
   const expires_at = requireDateTimeString(ctx, 'expires_at', obj.expires_at)
+  // credential_issuer is optional - not present in current backend response
+  const credential_issuer = obj.credential_issuer !== undefined
+    ? requireString(ctx, 'credential_issuer', obj.credential_issuer)
+    : undefined
   const issuer = validateIssuerSummary(obj.issuer)
 
   const rawTypes = requireArray(ctx, 'credential_types', obj.credential_types)
@@ -222,6 +264,7 @@ export function validateStartIssuanceResponse(raw: unknown): StartIssuanceRespon
   return {
     session_id,
     expires_at,
+    credential_issuer,
     issuer,
     credential_types,
     flow: flow as IssuanceFlow,
@@ -275,7 +318,8 @@ export function validateCredentialRecord(raw: unknown): CredentialRecord {
   if (!CREDENTIAL_FORMATS.includes(format as CredentialFormat))
     throw new ContractError(ctx, 'format', format)
 
-  const claims = requireObject(ctx, 'claims', obj.claims)
+  // Handle case where backend sends null for claims - treat as empty object
+  const claims = obj.claims === null ? {} : requireObject(ctx, 'claims', obj.claims)
 
   return {
     id: requireString(ctx, 'id', obj.id),
@@ -288,7 +332,7 @@ export function validateCredentialRecord(raw: unknown): CredentialRecord {
     issuer: requireString(ctx, 'issuer', obj.issuer),
     status: status as CredentialStatus,
     issued_at: requireString(ctx, 'issued_at', obj.issued_at),
-    expires_at: requireStringOrNull(ctx, 'expires_at', obj.expires_at),
+    expires_at: requireOptionalStringOrNull(ctx, 'expires_at', obj.expires_at),
     claims,
   }
 }
@@ -481,3 +525,4 @@ export function parseValidatedSsePayload(
       return null
   }
 }
+

--- a/src/components/issuance/CredentailOfferCard.tsx
+++ b/src/components/issuance/CredentailOfferCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { CredentialLogo, StartIssuanceResponse } from '../../types/issuance'
+import { resolveIssuerDisplay } from '../../utils/credentialDisplay'
 
 type IssuerBadgeProps = {
   displayName: string | null
@@ -111,6 +112,7 @@ type CredentialOfferCardProps = {
 }
 
 export function CredentialOfferCard({ session }: CredentialOfferCardProps) {
+  const issuerDisplay = resolveIssuerDisplay(session.issuer, session.credential_issuer)
   const expiresAt = new Date(session.expires_at)
   const expiresLabel = expiresAt.toLocaleTimeString(undefined, {
     hour: '2-digit',
@@ -135,9 +137,9 @@ export function CredentialOfferCard({ session }: CredentialOfferCardProps) {
           Issued by
         </p>
         <IssuerBadge
-          displayName={session.issuer.display_name}
-          credentialIssuer={session.issuer.credential_issuer}
-          logoUri={session.issuer.logo_uri}
+          displayName={issuerDisplay.name}
+          credentialIssuer={issuerDisplay.credentialIssuer}
+          logoUri={issuerDisplay.logoUri}
         />
       </div>
 
@@ -148,18 +150,25 @@ export function CredentialOfferCard({ session }: CredentialOfferCardProps) {
         <div className="flex flex-col gap-2">
           {session.credential_types.map((ct) => (
             <div key={ct.credential_configuration_id}>
-              <CredentialTypePill
-                name={ct.display.name}
-                backgroundColor={ct.display.background_color}
-                textColor={ct.display.text_color}
-                format={ct.format}
-                logo={ct.display.logo}
-              />
-              {ct.display.description && (
-                <p className="mt-1 px-1 text-xs leading-snug text-slate-500">
-                  {ct.display.description}
-                </p>
-              )}
+              {(() => {
+                const display = ct.display[0]!
+                return (
+                  <>
+                    <CredentialTypePill
+                      name={display.name}
+                      backgroundColor={display.background_color}
+                      textColor={display.text_color}
+                      format={ct.format}
+                      logo={display.logo}
+                    />
+                    {display.description && (
+                      <p className="mt-1 px-1 text-xs leading-snug text-slate-500">
+                        {display.description}
+                      </p>
+                    )}
+                  </>
+                )
+              })()}
             </div>
           ))}
         </div>

--- a/src/hooks/test/useIssuanceSession.test.ts
+++ b/src/hooks/test/useIssuanceSession.test.ts
@@ -18,7 +18,7 @@ const minimalSession: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'vc+sd-jwt',
+      format: 'dc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',

--- a/src/hooks/test/useIssuanceSession.test.ts
+++ b/src/hooks/test/useIssuanceSession.test.ts
@@ -10,22 +10,26 @@ import { CredentialOfferProvider } from '../../state/issuance.state'
 const minimalSession: StartIssuanceResponse = {
   session_id: 'ses_abc123',
   expires_at: '2026-04-08T14:35:00Z',
-  issuer: {
-    credential_issuer: 'https://issuer.example.eu',
-    display_name: 'Example Issuer',
-    logo_uri: null,
-  },
+  credential_issuer: 'https://issuer.example.eu',
+  issuer: [
+    {
+      name: 'Example Issuer',
+      locale: 'en-US',
+    },
+  ],
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
       format: 'dc+sd-jwt',
-      display: {
-        name: 'EU Personal ID',
-        description: 'Official EU personal identity document',
-        background_color: '#12107c',
-        text_color: '#ffffff',
-        logo: null,
-      },
+      display: [
+        {
+          name: 'EU Personal ID',
+          description: 'Official EU personal identity document',
+          background_color: '#12107c',
+          text_color: '#ffffff',
+          logo: null,
+        },
+      ],
     },
   ],
   flow: 'authorization_code',

--- a/src/hooks/test/useIssuanceSession.test.ts
+++ b/src/hooks/test/useIssuanceSession.test.ts
@@ -18,7 +18,7 @@ const minimalSession: StartIssuanceResponse = {
   credential_types: [
     {
       credential_configuration_id: 'eu.europa.ec.eudi.pid.1',
-      format: 'dc+sd-jwt',
+      format: 'vc+sd-jwt',
       display: {
         name: 'EU Personal ID',
         description: 'Official EU personal identity document',

--- a/src/pages/CredentialTypeDetailsPage.tsx
+++ b/src/pages/CredentialTypeDetailsPage.tsx
@@ -10,6 +10,7 @@ import { useCredentialOfferState } from '../state/issuance.state'
 import { submitConsent, submitTxCode, cancelSession } from '../api/issuance-session'
 import { useSseStream } from '../hooks/useSseStream'
 import { issuanceUserMessage, toIssuanceApiError } from '../utils/issuanceErrors'
+import { resolveIssuerDisplay } from '../utils/credentialDisplay'
 
 import type { ConsentResponse, IssuanceApiError, TxCodeSpec } from '../types/issuance'
 
@@ -32,26 +33,27 @@ type ClaimRow = { label: string; value: string }
 function buildDisplayRows(
   credType: NonNullable<ReturnType<typeof useSelectedType>>
 ): ClaimRow[] {
+  const display = credType.display[0]!
   const rows: ClaimRow[] = [
     { label: 'Credential Configuration ID', value: credType.credential_configuration_id },
     { label: 'Format', value: credType.format },
-    { label: 'Name', value: credType.display.name },
+    { label: 'Name', value: display.name },
   ]
 
-  if (credType.display.description) {
-    rows.push({ label: 'Description', value: credType.display.description })
+  if (display.description) {
+    rows.push({ label: 'Description', value: display.description })
   }
-  if (credType.display.background_color) {
-    rows.push({ label: 'Background Color', value: credType.display.background_color })
+  if (display.background_color) {
+    rows.push({ label: 'Background Color', value: display.background_color })
   }
-  if (credType.display.text_color) {
-    rows.push({ label: 'Text Color', value: credType.display.text_color })
+  if (display.text_color) {
+    rows.push({ label: 'Text Color', value: display.text_color })
   }
-  if (credType.display.logo?.uri) {
-    rows.push({ label: 'Logo URI', value: credType.display.logo.uri })
+  if (display.logo?.uri) {
+    rows.push({ label: 'Logo URI', value: display.logo.uri })
   }
-  if (credType.display.logo) {
-    rows.push({ label: 'Logo Alt Text', value: credType.display.logo.alt_text })
+  if (display.logo) {
+    rows.push({ label: 'Logo Alt Text', value: display.logo.alt_text })
   }
 
   return rows
@@ -167,10 +169,11 @@ export function CredentialTypeDetailsPage() {
   const session = offerState.offer
   const selectedType = useSelectedType(session, optionId)
 
-  const issuerName =
-    session?.issuer.display_name ??
-    (session ? new URL(session.issuer.credential_issuer).host : 'Issuer')
-  const issuerLogoUri = session?.issuer.logo_uri ?? null
+  const issuerDisplay = session
+    ? resolveIssuerDisplay(session.issuer, session.credential_issuer)
+    : null
+  const issuerName = issuerDisplay?.name ?? 'Issuer'
+  const issuerLogoUri = issuerDisplay?.logoUri ?? null
 
   const shouldRedirect = !session || !selectedType || !optionId
   useEffect(() => {
@@ -569,7 +572,7 @@ export function CredentialTypeDetailsPage() {
                 />
                 <div className="min-w-0">
                   <p className="truncate text-base font-semibold tracking-tight text-slate-900">
-                    {selectedType.display.name}
+                    {selectedType.display[0]!.name}
                   </p>
                   <p className="mt-0.5 truncate text-[14px] leading-relaxed text-slate-500">
                     {issuerName}

--- a/src/pages/CredentialTypesPage.tsx
+++ b/src/pages/CredentialTypesPage.tsx
@@ -6,6 +6,7 @@ import { PageContainer } from '../components/layout/PageContainer'
 import { credentialTypeDetailsPath, routes } from '../constants/routes'
 import { useCredentialOfferState } from '../state/issuance.state'
 import type { CredentialTypeDisplay } from '../types/issuance'
+import { resolveIssuerDisplay } from '../utils/credentialDisplay'
 
 type CredentialTypeCardProps = {
   credentialType: CredentialTypeDisplay
@@ -30,7 +31,7 @@ function CredentialTypeCard({
         <IssuerAvatar displayName={issuerName} logoUri={issuerLogoUri} size="md" />
         <div className="min-w-0">
           <p className="truncate text-base font-semibold tracking-tight text-slate-900">
-            {credentialType.display.name}
+            {credentialType.display[0]!.name}
           </p>
           <p className="mt-0.5 truncate text-[14px] leading-relaxed text-slate-500">
             {issuerName}
@@ -61,7 +62,7 @@ export function CredentialTypesPage() {
   if (!offerState.offer) return null
   const { issuer, credential_types } = offerState.offer
 
-  const issuerName = issuer.display_name ?? new URL(issuer.credential_issuer).host
+  const issuerDisplay = resolveIssuerDisplay(issuer, offerState.offer.credential_issuer)
 
   return (
     <PageContainer fullWidth>
@@ -87,8 +88,8 @@ export function CredentialTypesPage() {
               <li key={ct.credential_configuration_id}>
                 <CredentialTypeCard
                   credentialType={ct}
-                  issuerName={issuerName}
-                  issuerLogoUri={issuer.logo_uri}
+                  issuerName={issuerDisplay.name}
+                  issuerLogoUri={issuerDisplay.logoUri}
                   onClick={(id) => navigate(credentialTypeDetailsPath(id))}
                 />
               </li>

--- a/src/pages/tests/CredentialTypeDetailsPage.test.tsx
+++ b/src/pages/tests/CredentialTypeDetailsPage.test.tsx
@@ -68,7 +68,7 @@ function buildOffer(
     credential_types: [
       {
         credential_configuration_id: 'identity_credential',
-        format: 'vc+sd-jwt',
+        format: 'dc+sd-jwt',
         display: {
           name: 'Identity Credential',
           description: 'Official identity document',
@@ -1024,7 +1024,7 @@ describe('CredentialTypeDetailsPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'identity_credential',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { name: 'Identity Credential' },
         },
       ],

--- a/src/pages/tests/CredentialTypeDetailsPage.test.tsx
+++ b/src/pages/tests/CredentialTypeDetailsPage.test.tsx
@@ -68,7 +68,7 @@ function buildOffer(
     credential_types: [
       {
         credential_configuration_id: 'identity_credential',
-        format: 'dc+sd-jwt',
+        format: 'vc+sd-jwt',
         display: {
           name: 'Identity Credential',
           description: 'Official identity document',
@@ -1024,7 +1024,7 @@ describe('CredentialTypeDetailsPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'identity_credential',
-          format: 'dc+sd-jwt',
+          format: 'vc+sd-jwt',
           display: { name: 'Identity Credential' },
         },
       ],

--- a/src/pages/tests/CredentialTypeDetailsPage.test.tsx
+++ b/src/pages/tests/CredentialTypeDetailsPage.test.tsx
@@ -60,25 +60,33 @@ function buildOffer(
   return {
     session_id: 'ses_123',
     expires_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
-    issuer: {
-      credential_issuer: 'https://issuer.example.org',
-      display_name: 'Example Issuer',
-      logo_uri: null,
-    },
+    credential_issuer: 'https://issuer.example.org',
+    issuer: [
+      {
+        name: 'Example Issuer',
+        locale: 'en-US',
+        logo: {
+          uri: 'https://issuer.example.org/logo.svg',
+          alt_text: 'Issuer logo',
+        },
+      },
+    ],
     credential_types: [
       {
         credential_configuration_id: 'identity_credential',
         format: 'dc+sd-jwt',
-        display: {
-          name: 'Identity Credential',
-          description: 'Official identity document',
-          background_color: '#12107c',
-          text_color: '#ffffff',
-          logo: {
-            uri: 'https://issuer.example.org/logo.svg',
-            alt_text: 'Issuer logo',
+        display: [
+          {
+            name: 'Identity Credential',
+            description: 'Official identity document',
+            background_color: '#12107c',
+            text_color: '#ffffff',
+            logo: {
+              uri: 'https://issuer.example.org/logo.svg',
+              alt_text: 'Issuer logo',
+            },
           },
-        },
+        ],
       },
     ],
     flow: 'authorization_code',
@@ -554,13 +562,27 @@ describe('CredentialTypeDetailsPage', () => {
     })
   })
 
-  it('falls back to issuer host when display_name is missing', () => {
+  it('falls back to issuer host when display array is empty', () => {
     mockOfferState.offer = buildOffer({
-      issuer: {
-        credential_issuer: 'https://issuer-host.example.org',
-        display_name: null,
-        logo_uri: null,
-      },
+      credential_issuer: 'https://issuer-host.example.org',
+      issuer: [],
+    })
+    renderPage()
+    expect(screen.getByText('issuer-host.example.org')).toBeTruthy()
+  })
+
+  it('falls back to issuer host when first display entry has no name', () => {
+    mockOfferState.offer = buildOffer({
+      credential_issuer: 'https://issuer-host.example.org',
+      issuer: [
+        {
+          locale: 'en-US',
+          logo: {
+            uri: 'https://issuer.example.org/logo.png',
+            alt_text: 'Issuer logo',
+          },
+        },
+      ],
     })
     renderPage()
     expect(screen.getByText('issuer-host.example.org')).toBeTruthy()
@@ -1025,7 +1047,7 @@ describe('CredentialTypeDetailsPage', () => {
         {
           credential_configuration_id: 'identity_credential',
           format: 'dc+sd-jwt',
-          display: { name: 'Identity Credential' },
+          display: [{ name: 'Identity Credential' }],
         },
       ],
     })

--- a/src/pages/tests/CredentialTypesPage.test.tsx
+++ b/src/pages/tests/CredentialTypesPage.test.tsx
@@ -34,21 +34,27 @@ function baseOffer(
   return {
     session_id: 'ses_test',
     expires_at: '2026-04-08T14:35:00Z',
-    issuer: {
-      credential_issuer: 'https://issuer.example.org',
-      display_name: 'Keycloak-demo',
-      logo_uri: 'https://issuer.example.org/logo.png',
-    },
+    credential_issuer: 'https://issuer.example.org',
+    issuer: [
+      {
+        name: 'Keycloak-demo',
+        locale: 'en-US',
+        logo: {
+          uri: 'https://issuer.example.org/logo.png',
+          alt_text: 'Issuer logo',
+        },
+      },
+    ],
     credential_types: [
       {
         credential_configuration_id: 'pid',
         format: 'dc+sd-jwt',
-        display: { name: 'Personal ID' },
+        display: [{ name: 'Personal ID' }],
       },
       {
         credential_configuration_id: 'address',
         format: 'dc+sd-jwt',
-        display: { name: 'Address Credential' },
+        display: [{ name: 'Address Credential' }],
       },
     ],
     flow: 'pre_authorized_code',
@@ -113,13 +119,10 @@ describe('CredentialTypesPage', () => {
     expect(screen.getAllByText('Keycloak-demo').length).toBeGreaterThan(0)
   })
 
-  it('falls back to hostname (not raw URL) when display_name is null', () => {
+  it('falls back to hostname when display array is empty', () => {
     mockOfferState.offer = baseOffer({
-      issuer: {
-        credential_issuer: 'https://fallback.example.org',
-        display_name: null,
-        logo_uri: null,
-      },
+      credential_issuer: 'https://fallback.example.org',
+      issuer: [],
     })
     renderPage()
     expect(screen.getAllByText('fallback.example.org').length).toBeGreaterThan(0)
@@ -135,18 +138,15 @@ describe('CredentialTypesPage', () => {
     expect(logos[0]?.getAttribute('src')).toBe('https://issuer.example.org/logo.png')
   })
 
-  it('shows initials placeholder when logo_uri is null', () => {
+  it('shows initials placeholder when display entry has no logo', () => {
     mockOfferState.offer = baseOffer({
-      issuer: {
-        credential_issuer: 'https://issuer.example.org',
-        display_name: 'My Issuer',
-        logo_uri: null,
-      },
+      credential_issuer: 'https://issuer.example.org',
+      issuer: [{ name: 'My Issuer', locale: 'en-US' }],
       credential_types: [
         {
           credential_configuration_id: 'a',
           format: 'dc+sd-jwt',
-          display: { name: 'Type A' },
+          display: [{ name: 'Type A' }],
         },
       ],
     })
@@ -157,16 +157,22 @@ describe('CredentialTypesPage', () => {
 
   it('swaps logo to initials placeholder when logo URL is present but image fails to load', async () => {
     mockOfferState.offer = baseOffer({
-      issuer: {
-        credential_issuer: 'https://issuer.example.org',
-        display_name: 'Keycloak-demo',
-        logo_uri: 'https://issuer.example.org/broken.png',
-      },
+      credential_issuer: 'https://issuer.example.org',
+      issuer: [
+        {
+          name: 'Keycloak-demo',
+          locale: 'en-US',
+          logo: {
+            uri: 'https://issuer.example.org/broken.png',
+            alt_text: 'Issuer logo',
+          },
+        },
+      ],
       credential_types: [
         {
           credential_configuration_id: 'pid',
           format: 'dc+sd-jwt',
-          display: { name: 'Personal ID' },
+          display: [{ name: 'Personal ID' }],
         },
       ],
     })

--- a/src/pages/tests/CredentialTypesPage.test.tsx
+++ b/src/pages/tests/CredentialTypesPage.test.tsx
@@ -42,12 +42,12 @@ function baseOffer(
     credential_types: [
       {
         credential_configuration_id: 'pid',
-        format: 'dc+sd-jwt',
+        format: 'vc+sd-jwt',
         display: { name: 'Personal ID' },
       },
       {
         credential_configuration_id: 'address',
-        format: 'dc+sd-jwt',
+        format: 'vc+sd-jwt',
         display: { name: 'Address Credential' },
       },
     ],
@@ -145,7 +145,7 @@ describe('CredentialTypesPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'a',
-          format: 'dc+sd-jwt',
+          format: 'vc+sd-jwt',
           display: { name: 'Type A' },
         },
       ],
@@ -165,7 +165,7 @@ describe('CredentialTypesPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'pid',
-          format: 'dc+sd-jwt',
+          format: 'vc+sd-jwt',
           display: { name: 'Personal ID' },
         },
       ],

--- a/src/pages/tests/CredentialTypesPage.test.tsx
+++ b/src/pages/tests/CredentialTypesPage.test.tsx
@@ -42,12 +42,12 @@ function baseOffer(
     credential_types: [
       {
         credential_configuration_id: 'pid',
-        format: 'vc+sd-jwt',
+        format: 'dc+sd-jwt',
         display: { name: 'Personal ID' },
       },
       {
         credential_configuration_id: 'address',
-        format: 'vc+sd-jwt',
+        format: 'dc+sd-jwt',
         display: { name: 'Address Credential' },
       },
     ],
@@ -145,7 +145,7 @@ describe('CredentialTypesPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'a',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { name: 'Type A' },
         },
       ],
@@ -165,7 +165,7 @@ describe('CredentialTypesPage', () => {
       credential_types: [
         {
           credential_configuration_id: 'pid',
-          format: 'vc+sd-jwt',
+          format: 'dc+sd-jwt',
           display: { name: 'Personal ID' },
         },
       ],

--- a/src/types/credential.ts
+++ b/src/types/credential.ts
@@ -46,8 +46,9 @@ export type CredentialRecord = {
   /**
    * ISO 8601 expiry timestamp.
    * `null` when the credential has no expiry.
+   * `undefined` when the field is omitted from the response.
    */
-  expires_at: string | null
+  expires_at: string | null | undefined
   /**
    * Decoded credential claims.
    * Structure is credential-type specific; additional properties permitted.

--- a/src/types/issuance.ts
+++ b/src/types/issuance.ts
@@ -1,8 +1,15 @@
-export type IssuerSummary = {
-  credential_issuer: string
-  display_name: string | null
-  logo_uri: string | null
+export type IssuerDisplayEntry = {
+  name?: string
+  locale?: string
+  logo?: {
+    uri: string
+    alt_text?: string
+  }
+  description?: string
 }
+
+// IssuerSummary is directly the display array per OpenAPI spec
+export type IssuerSummary = IssuerDisplayEntry[]
 
 export type CredentialLogo = {
   uri: string
@@ -20,7 +27,7 @@ export type CredentialDisplay = {
 export type CredentialTypeDisplay = {
   credential_configuration_id: string
   format: string
-  display: CredentialDisplay
+  display: CredentialDisplay[]
 }
 
 export type TxCodeSpec = {
@@ -34,6 +41,7 @@ export type IssuanceFlow = 'authorization_code' | 'pre_authorized_code'
 export type StartIssuanceResponse = {
   session_id: string
   expires_at: string
+  credential_issuer?: string
   issuer: IssuerSummary
   credential_types: CredentialTypeDisplay[]
   flow: IssuanceFlow

--- a/src/utils/credentialDisplay.ts
+++ b/src/utils/credentialDisplay.ts
@@ -1,4 +1,5 @@
 import type { CredentialRecord } from '../types/credential'
+import type { CredentialDisplay, IssuerDisplayEntry } from '../types/issuance'
 
 /**
  * Returns the last non-empty path segment of a string, stripping trailing slashes.
@@ -38,4 +39,54 @@ export function issuerDisplayLabel(issuer: string): string {
   } catch {
     return issuer
   }
+}
+
+/**
+ * Resolves issuer display metadata from the structured display array.
+ *
+ * Per OID4VCI spec, the display array contains locale-specific entries.
+ * For v1, we use the first entry. When no display metadata is provided,
+ * we fall back to the credential_issuer hostname.
+ *
+ * @param display - The issuer display array from StartIssuanceResponse.issuer
+ * @param credentialIssuer - The credential_issuer URL for fallback (optional)
+ * @returns Object with resolved name and logoUri (null if no logo available)
+ */
+export function resolveIssuerDisplay(
+  display: IssuerDisplayEntry[],
+  credentialIssuer?: string
+): { name: string; logoUri: string | null; credentialIssuer: string } {
+  // Determine the credential issuer URL to use for fallbacks
+  // Per OpenAPI spec, when no display metadata is available, the backend
+  // returns a single entry with `name` set to the credential_issuer URL
+  const effectiveCredentialIssuer = credentialIssuer ?? display[0]?.name ?? 'Unknown Issuer'
+  const fallbackName = issuerDisplayLabel(effectiveCredentialIssuer)
+
+  // If display array is empty, use fallbacks
+  if (display.length === 0) {
+    return { name: fallbackName, logoUri: null, credentialIssuer: effectiveCredentialIssuer }
+  }
+
+  const entry = display[0]
+
+  // Use entry name if present, otherwise fall back to hostname
+  const name = entry.name ?? fallbackName
+
+  // Use logo URI if present, otherwise null
+  const logoUri = entry.logo?.uri ?? null
+
+  return { name, logoUri, credentialIssuer: effectiveCredentialIssuer }
+}
+
+/**
+ * Resolves the first display entry from the credential display array.
+ *
+ * Per OID4VCI spec, the display array contains locale-specific entries.
+ * For v1, we use the first entry.
+ *
+ * @param display - The credential display array from CredentialTypeDisplay.display
+ * @returns The first CredentialDisplay entry
+ */
+export function resolveCredentialDisplay(display: CredentialDisplay[]): CredentialDisplay {
+  return display[0]!
 }

--- a/src/utils/credentialDisplay.ts
+++ b/src/utils/credentialDisplay.ts
@@ -59,12 +59,17 @@ export function resolveIssuerDisplay(
   // Determine the credential issuer URL to use for fallbacks
   // Per OpenAPI spec, when no display metadata is available, the backend
   // returns a single entry with `name` set to the credential_issuer URL
-  const effectiveCredentialIssuer = credentialIssuer ?? display[0]?.name ?? 'Unknown Issuer'
+  const effectiveCredentialIssuer =
+    credentialIssuer ?? display[0]?.name ?? 'Unknown Issuer'
   const fallbackName = issuerDisplayLabel(effectiveCredentialIssuer)
 
   // If display array is empty, use fallbacks
   if (display.length === 0) {
-    return { name: fallbackName, logoUri: null, credentialIssuer: effectiveCredentialIssuer }
+    return {
+      name: fallbackName,
+      logoUri: null,
+      credentialIssuer: effectiveCredentialIssuer,
+    }
   }
 
   const entry = display[0]
@@ -87,6 +92,8 @@ export function resolveIssuerDisplay(
  * @param display - The credential display array from CredentialTypeDisplay.display
  * @returns The first CredentialDisplay entry
  */
-export function resolveCredentialDisplay(display: CredentialDisplay[]): CredentialDisplay {
+export function resolveCredentialDisplay(
+  display: CredentialDisplay[]
+): CredentialDisplay {
   return display[0]!
 }

--- a/src/utils/tests/credentialDisplay.test.ts
+++ b/src/utils/tests/credentialDisplay.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { CredentialRecord } from '../../types/credential'
-import { credentialDisplayName, issuerDisplayLabel } from '../credentialDisplay'
+import type { IssuerDisplayEntry } from '../../types/issuance'
+import {
+  credentialDisplayName,
+  issuerDisplayLabel,
+  resolveIssuerDisplay,
+} from '../credentialDisplay'
 
 function makeCredential(overrides: Partial<CredentialRecord> = {}): CredentialRecord {
   return {
@@ -63,5 +68,66 @@ describe('issuerDisplayLabel', () => {
     expect(issuerDisplayLabel('https://issuer.example.com:8443/oid4vci')).toBe(
       'issuer.example.com:8443'
     )
+  })
+})
+
+describe('resolveIssuerDisplay', () => {
+  const defaultCredentialIssuer = 'https://issuer.example.com'
+
+  it('uses name and logo from the first display entry', () => {
+    const display: IssuerDisplayEntry[] = [
+      {
+        name: 'Example Issuer',
+        locale: 'en-US',
+        logo: { uri: 'https://issuer.example.com/logo.png', alt_text: 'Logo' },
+        description: 'An example issuer',
+      },
+    ]
+    const result = resolveIssuerDisplay(display, defaultCredentialIssuer)
+    expect(result.name).toBe('Example Issuer')
+    expect(result.logoUri).toBe('https://issuer.example.com/logo.png')
+  })
+
+  it('falls back to hostname when first entry has no name', () => {
+    const credentialIssuer = 'https://wallet-issuer.example.org/path'
+    const display: IssuerDisplayEntry[] = [
+      {
+        logo: { uri: 'https://issuer.example.com/logo.png', alt_text: 'Logo' },
+      },
+    ]
+    const result = resolveIssuerDisplay(display, credentialIssuer)
+    expect(result.name).toBe('wallet-issuer.example.org')
+    expect(result.logoUri).toBe('https://issuer.example.com/logo.png')
+  })
+
+  it('falls back to hostname when display array is empty', () => {
+    const credentialIssuer = 'https://wallet-issuer.example.org'
+    const display: IssuerDisplayEntry[] = []
+    const result = resolveIssuerDisplay(display, credentialIssuer)
+    expect(result.name).toBe('wallet-issuer.example.org')
+    expect(result.logoUri).toBeNull()
+  })
+
+  it('returns null logoUri when first entry has no logo', () => {
+    const display: IssuerDisplayEntry[] = [{ name: 'Example Issuer', locale: 'en-US' }]
+    const result = resolveIssuerDisplay(display, defaultCredentialIssuer)
+    expect(result.name).toBe('Example Issuer')
+    expect(result.logoUri).toBeNull()
+  })
+
+  it('handles entry with only optional fields missing', () => {
+    const display: IssuerDisplayEntry[] = [{ name: 'Minimal Issuer' }]
+    const result = resolveIssuerDisplay(display, defaultCredentialIssuer)
+    expect(result.name).toBe('Minimal Issuer')
+    expect(result.logoUri).toBeNull()
+  })
+
+  it('uses first entry when multiple display entries exist', () => {
+    const display: IssuerDisplayEntry[] = [
+      { name: 'First Entry', locale: 'en-US' },
+      { name: 'Second Entry', locale: 'de-DE' },
+    ]
+    const result = resolveIssuerDisplay(display, defaultCredentialIssuer)
+    expect(result.name).toBe('First Entry')
   })
 })


### PR DESCRIPTION
he backend changed `IssuerSummary` from a flat object with `display_name` and `logo_uri` fields to a structured `display` array matching the OID4VCI issuer metadata format.

This is a breaking shape change — every frontend callsite that reads the old fields must be updated.

---

## Shape change — old vs new

### Before

```ts
issuer: {
  credential_issuer: string
  display_name: string | null
  logo_uri: string | null
}
```

### After

```ts
issuer: {
  credential_issuer: string
  display: Array<{
    name?: string
    locale?: string
    logo?: { uri, alt_text }
    description?: string
  }>
}
```

---

## Background

The backend now exposes the raw `display` array from the OID4VCI issuer metadata object verbatim.

Each entry is locale-specific and all fields are optional per the spec.

When the issuer provides no display metadata the backend returns an empty array `[]`.

The frontend is responsible for locale selection. Until a locale-aware picker is implemented, use the first entry of the array as the display metadata.

Fall back to the bare `credential_issuer` hostname when:

* the array is empty
* the selected entry has no `name`

Spec ref:

* `POST /issuance/start`
* `StartIssuanceResponse.issuer`
* `IssuerSummary`
* `IssuerDisplayEntry`
