### PR TITLE
fix(ui): persist credentials cache to localStorage to survive page refreshes

### DIFF
--- a/src/state/credentialsCache.state.tsx
+++ b/src/state/credentialsCache.state.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { CredentialListItem } from '../types/credential'
+
+const STORAGE_KEY = 'cloud_wallet_credentials_cache'
 
 export type CredentialsCacheState = {
   /** Cached credentials from the list endpoint with display metadata */
@@ -13,12 +15,69 @@ export type CredentialsCacheState = {
   clear: () => void
 }
 
+/**
+ * Serialize credentials to localStorage-compatible format
+ */
+function serializeCredentials(credentials: Map<string, CredentialListItem>): string {
+  const entries = Array.from(credentials.entries())
+  return JSON.stringify(entries)
+}
+
+/**
+ * Deserialize credentials from localStorage
+ */
+function deserializeCredentials(data: string): Map<string, CredentialListItem> {
+  try {
+    const entries = JSON.parse(data) as [string, CredentialListItem][]
+    return new Map(entries)
+  } catch {
+    return new Map()
+  }
+}
+
+/**
+ * Load credentials from localStorage
+ */
+function loadFromStorage(): Map<string, CredentialListItem> {
+  if (typeof window === 'undefined') {
+    return new Map()
+  }
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      return deserializeCredentials(stored)
+    }
+  } catch {
+    // Ignore storage errors (e.g., private browsing mode)
+  }
+  return new Map()
+}
+
+/**
+ * Save credentials to localStorage
+ */
+function saveToStorage(credentials: Map<string, CredentialListItem>): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, serializeCredentials(credentials))
+  } catch {
+    // Ignore storage errors (e.g., quota exceeded, private browsing mode)
+  }
+}
+
 const CredentialsCacheContext = createContext<CredentialsCacheState | null>(null)
 
 export function CredentialsCacheProvider({ children }: { children: React.ReactNode }) {
   const [credentials, setCredentialsMap] = useState<Map<string, CredentialListItem>>(
-    new Map()
+    () => loadFromStorage()
   )
+
+  // Persist to localStorage whenever credentials change
+  useEffect(() => {
+    saveToStorage(credentials)
+  }, [credentials])
 
   const getCredential = useCallback(
     (id: string): CredentialListItem | undefined => {
@@ -39,6 +98,13 @@ export function CredentialsCacheProvider({ children }: { children: React.ReactNo
 
   const clear = useCallback(() => {
     setCredentialsMap(new Map())
+    if (typeof window !== 'undefined') {
+      try {
+        localStorage.removeItem(STORAGE_KEY)
+      } catch {
+        // Ignore storage errors
+      }
+    }
   }, [])
 
   const value = useMemo<CredentialsCacheState>(

--- a/src/state/credentialsCache.state.tsx
+++ b/src/state/credentialsCache.state.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import type { CredentialListItem } from '../types/credential'
 
 const STORAGE_KEY = 'cloud_wallet_credentials_cache'
@@ -70,8 +77,8 @@ function saveToStorage(credentials: Map<string, CredentialListItem>): void {
 const CredentialsCacheContext = createContext<CredentialsCacheState | null>(null)
 
 export function CredentialsCacheProvider({ children }: { children: React.ReactNode }) {
-  const [credentials, setCredentialsMap] = useState<Map<string, CredentialListItem>>(
-    () => loadFromStorage()
+  const [credentials, setCredentialsMap] = useState<Map<string, CredentialListItem>>(() =>
+    loadFromStorage()
   )
 
   // Persist to localStorage whenever credentials change


### PR DESCRIPTION
## Problem
When a user navigated to the credential detail page and refreshed the browser, the credential card would lose its display styling (background color, logo, issuer name, etc.). This happened because the display metadata was only stored in React state (memory), which is lost on page refresh.

The backend's `/credentials/{id}` endpoint doesn't return display metadata, but the `/credentials` list endpoint does. We were caching this metadata in memory via `useCredentialsCache`, but it wasn't persisted.

## Solution
Modified `credentialsCache.state.tsx` to persist the credentials cache to `localStorage`:

- Added `loadFromStorage()` to restore cache from localStorage on app initialization
- Added `saveToStorage()` to persist cache whenever credentials change
- Added serialization/deserialization helpers for Map <-> JSON conversion
- Used lazy state initialization to load from storage immediately
- Updated `clear()` to also remove the localStorage entry
- Wrapped all storage operations in try-catch for graceful handling of private browsing mode

## How to Test
1. Navigate to the Credentials page
2. Click on any credential to view its detail page
3. Observe the styled credential card (background color, logo, etc.)
4. Refresh the page
5. **Before this fix**: Card would lose styling and show generic appearance
6. **After this fix**: Card retains its styling from the cached display metadata

## Files Changed
- `cloud-wallet-ui/src/state/credentialsCache.state.tsx` - Added localStorage persistence