### PR TITLE
Add PresentationProvider for managing presentation state and persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Navigate, Route, BrowserRouter as Router, Routes } from 'react-router-d
 import { ScanPage } from './pages/ScanPage'
 import { routes } from './constants/routes'
 import { CredentialOfferProvider } from './state/issuance.state'
+import { PresentationProvider } from './state/presentation.state'
 import { CredentialsCacheProvider } from './state/credentialsCache.state'
 import { CredentialTypesPage } from './pages/CredentialTypesPage'
 import { IssuanceSuccessPage } from './pages/IssuanceSuccessPage'
@@ -25,96 +26,98 @@ function RequireRegistration({ children }: { children: ReactNode }) {
 function App() {
   return (
     <CredentialOfferProvider>
-      <CredentialsCacheProvider>
-        <Router>
-          <Routes>
-            <Route
-              path={routes.registration}
-              element={
-                getStoredTenantId() ? (
-                  <Navigate to={routes.home} replace />
-                ) : (
-                  <RegistrationPage />
-                )
-              }
-            />
-            <Route
-              path={routes.home}
-              element={
-                <RequireRegistration>
-                  <HomePage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path={routes.scan}
-              element={
-                <RequireRegistration>
-                  <ScanPage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path={routes.credentialTypeDetails}
-              element={
-                <RequireRegistration>
-                  <CredentialTypeDetailsPage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path={routes.credentialTypes}
-              element={
-                <RequireRegistration>
-                  <CredentialTypesPage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path={routes.issuanceSuccess}
-              element={
-                <RequireRegistration>
-                  <IssuanceSuccessPage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path={routes.credentials}
-              element={
-                <RequireRegistration>
-                  <CredentialsPage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path={`${routes.credentials}/:credentialId/remove`}
-              element={
-                <RequireRegistration>
-                  <RemoveCredentialPage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path={`${routes.credentials}/:credentialId`}
-              element={
-                <RequireRegistration>
-                  <CredentialDetailPage />
-                </RequireRegistration>
-              }
-            />
-            <Route
-              path="*"
-              element={
-                getStoredTenantId() ? (
-                  <Navigate to={routes.home} replace />
-                ) : (
-                  <Navigate to={routes.registration} replace />
-                )
-              }
-            />
-          </Routes>
-        </Router>
-      </CredentialsCacheProvider>
+      <PresentationProvider>
+        <CredentialsCacheProvider>
+          <Router>
+            <Routes>
+              <Route
+                path={routes.registration}
+                element={
+                  getStoredTenantId() ? (
+                    <Navigate to={routes.home} replace />
+                  ) : (
+                    <RegistrationPage />
+                  )
+                }
+              />
+              <Route
+                path={routes.home}
+                element={
+                  <RequireRegistration>
+                    <HomePage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={routes.scan}
+                element={
+                  <RequireRegistration>
+                    <ScanPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={routes.credentialTypeDetails}
+                element={
+                  <RequireRegistration>
+                    <CredentialTypeDetailsPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={routes.credentialTypes}
+                element={
+                  <RequireRegistration>
+                    <CredentialTypesPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={routes.issuanceSuccess}
+                element={
+                  <RequireRegistration>
+                    <IssuanceSuccessPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={routes.credentials}
+                element={
+                  <RequireRegistration>
+                    <CredentialsPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={`${routes.credentials}/:credentialId/remove`}
+                element={
+                  <RequireRegistration>
+                    <RemoveCredentialPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={`${routes.credentials}/:credentialId`}
+                element={
+                  <RequireRegistration>
+                    <CredentialDetailPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path="*"
+                element={
+                  getStoredTenantId() ? (
+                    <Navigate to={routes.home} replace />
+                  ) : (
+                    <Navigate to={routes.registration} replace />
+                  )
+                }
+              />
+            </Routes>
+          </Router>
+        </CredentialsCacheProvider>
+      </PresentationProvider>
     </CredentialOfferProvider>
   )
 }

--- a/src/state/presentation.state.tsx
+++ b/src/state/presentation.state.tsx
@@ -23,6 +23,11 @@ const STORAGE_KEY = 'cloud_wallet_presentation_flow'
 
 const IDLE_STATE: PersistedPresentationState = { status: 'idle' }
 
+const DEFAULT_SUBMISSION_FAILED_ERROR: PresentationError = {
+  code: 'submission_failed',
+  message: 'Presentation submission failed.',
+}
+
 function isTerminalStatus(status: PresentationStatus): boolean {
   return status === 'success' || status === 'error'
 }
@@ -47,14 +52,82 @@ function isPresentationStatus(value: unknown): value is PresentationStatus {
   )
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isVerifierMetadata(value: unknown): value is VerifierMetadata {
+  return isRecord(value) && typeof value.client_id === 'string'
+}
+
+function isParsedPresentationRequest(value: unknown): value is ParsedPresentationRequest {
+  return isRecord(value)
+}
+
+function isMatchingCredential(value: unknown): value is MatchingCredential {
+  return (
+    isRecord(value) &&
+    typeof value.credentialId === 'string' &&
+    typeof value.queryId === 'string' &&
+    typeof value.format === 'string'
+  )
+}
+
+function isSelectedCredential(value: unknown): value is SelectedCredential {
+  return isMatchingCredential(value)
+}
+
+function isDisclosedClaimMap(value: unknown): value is DisclosedClaimMap {
+  if (!isRecord(value)) return false
+  return Object.values(value).every(
+    (claims) =>
+      Array.isArray(claims) && claims.every((claim) => typeof claim === 'string')
+  )
+}
+
+function isPresentationError(value: unknown): value is PresentationError {
+  return (
+    isRecord(value) && typeof value.code === 'string' && typeof value.message === 'string'
+  )
+}
+
+function validatePersistedFields(
+  record: Record<string, unknown>
+): PersistedPresentationState | null {
+  if (record.verifier !== undefined && !isVerifierMetadata(record.verifier)) return null
+  if (record.request !== undefined && !isParsedPresentationRequest(record.request))
+    return null
+  if (record.error !== undefined && !isPresentationError(record.error)) return null
+  if (
+    record.matchingCredentials !== undefined &&
+    (!Array.isArray(record.matchingCredentials) ||
+      !record.matchingCredentials.every(isMatchingCredential))
+  ) {
+    return null
+  }
+  if (
+    record.selectedCredentials !== undefined &&
+    (!Array.isArray(record.selectedCredentials) ||
+      !record.selectedCredentials.every(isSelectedCredential))
+  ) {
+    return null
+  }
+  if (
+    record.disclosedClaims !== undefined &&
+    !isDisclosedClaimMap(record.disclosedClaims)
+  ) {
+    return null
+  }
+  return record as PersistedPresentationState
+}
+
 function parsePersistedState(raw: string): PersistedPresentationState | null {
   try {
     const parsed: unknown = JSON.parse(raw)
-    if (!parsed || typeof parsed !== 'object') return null
-    const record = parsed as Record<string, unknown>
-    if (!isPresentationStatus(record.status)) return null
-    if (!isPersistableStatus(record.status)) return null
-    return parsed as PersistedPresentationState
+    if (!isRecord(parsed)) return null
+    if (!isPresentationStatus(parsed.status)) return null
+    if (!isPersistableStatus(parsed.status)) return null
+    return validatePersistedFields(parsed)
   } catch {
     return null
   }
@@ -107,7 +180,11 @@ export type PresentationState = PersistedPresentationState & {
   setMatchingCredentials: (credentials: MatchingCredential[]) => void
   setSelectedCredentials: (credentials: SelectedCredential[]) => void
   setDisclosedClaims: (claims: DisclosedClaimMap) => void
-  setSubmissionResult: (result: PresentationResult) => void
+  /**
+   * Sets submission outcome and terminal status. On failure, uses `error` when provided,
+   * otherwise keeps an existing error or falls back to `submission_failed`.
+   */
+  setSubmissionResult: (result: PresentationResult, error?: PresentationError) => void
   setError: (error: PresentationError) => void
   /** Reset all presentation state and remove persisted data. */
   clear: () => void
@@ -115,6 +192,7 @@ export type PresentationState = PersistedPresentationState & {
 
 const PresentationContext = createContext<PresentationState | null>(null)
 
+/** In-progress flow state is persisted; terminal success/error stays in memory until `clear()`. */
 export function PresentationProvider({ children }: { children: React.ReactNode }) {
   const [data, setData] = useState<PersistedPresentationState>(loadFromStorage)
 
@@ -126,6 +204,15 @@ export function PresentationProvider({ children }: { children: React.ReactNode }
     saveToStorage(data)
   }, [data])
 
+  const clear = useCallback(() => {
+    setData(IDLE_STATE)
+    removeFromStorage()
+  }, [])
+
+  /**
+   * Updates lifecycle status only. Does not reset request, credentials, or disclosure fields.
+   * Call `clear()` when starting a new presentation flow or after the user leaves a result screen.
+   */
   const setStatus = useCallback((status: PresentationStatus) => {
     setData((prev) => {
       if (status === 'success') {
@@ -136,7 +223,15 @@ export function PresentationProvider({ children }: { children: React.ReactNode }
   }, [])
 
   const setRequest = useCallback((request: ParsedPresentationRequest) => {
-    setData((prev) => ({ ...prev, request }))
+    setData((prev) => ({
+      ...prev,
+      request,
+      matchingCredentials: undefined,
+      selectedCredentials: undefined,
+      disclosedClaims: undefined,
+      submissionResult: undefined,
+      error: undefined,
+    }))
   }, [])
 
   const setVerifier = useCallback((verifier: VerifierMetadata) => {
@@ -145,7 +240,12 @@ export function PresentationProvider({ children }: { children: React.ReactNode }
 
   const setMatchingCredentials = useCallback(
     (matchingCredentials: MatchingCredential[]) => {
-      setData((prev) => ({ ...prev, matchingCredentials }))
+      setData((prev) => ({
+        ...prev,
+        matchingCredentials,
+        selectedCredentials: undefined,
+        disclosedClaims: undefined,
+      }))
     },
     []
   )
@@ -161,14 +261,19 @@ export function PresentationProvider({ children }: { children: React.ReactNode }
     setData((prev) => ({ ...prev, disclosedClaims }))
   }, [])
 
-  const setSubmissionResult = useCallback((submissionResult: PresentationResult) => {
-    setData((prev) => ({
-      ...prev,
-      submissionResult,
-      status: submissionResult.success ? 'success' : 'error',
-      error: submissionResult.success ? undefined : prev.error,
-    }))
-  }, [])
+  const setSubmissionResult = useCallback(
+    (submissionResult: PresentationResult, error?: PresentationError) => {
+      setData((prev) => ({
+        ...prev,
+        submissionResult,
+        status: submissionResult.success ? 'success' : 'error',
+        error: submissionResult.success
+          ? undefined
+          : (error ?? prev.error ?? DEFAULT_SUBMISSION_FAILED_ERROR),
+      }))
+    },
+    []
+  )
 
   const setError = useCallback((error: PresentationError) => {
     setData((prev) => ({
@@ -178,16 +283,6 @@ export function PresentationProvider({ children }: { children: React.ReactNode }
       submissionResult: undefined,
     }))
   }, [])
-
-  const clear = useCallback(() => {
-    setData(IDLE_STATE)
-    removeFromStorage()
-  }, [])
-
-  useEffect(() => {
-    if (!isTerminalStatus(data.status)) return
-    clear()
-  }, [clear, data.status])
 
   const isFlowActive =
     data.status !== 'idle' && data.status !== 'success' && data.status !== 'error'
@@ -233,3 +328,15 @@ export function usePresentationState(): PresentationState {
   }
   return ctx
 }
+
+export type {
+  DisclosedClaimMap,
+  MatchingCredential,
+  ParsedPresentationRequest,
+  PresentationError,
+  PresentationErrorCode,
+  PresentationResult,
+  PresentationStatus,
+  SelectedCredential,
+  VerifierMetadata,
+} from '../types/presentation'

--- a/src/state/presentation.state.tsx
+++ b/src/state/presentation.state.tsx
@@ -1,0 +1,235 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import type {
+  DisclosedClaimMap,
+  MatchingCredential,
+  ParsedPresentationRequest,
+  PersistedPresentationState,
+  PresentationError,
+  PresentationResult,
+  PresentationStatus,
+  SelectedCredential,
+  VerifierMetadata,
+} from '../types/presentation'
+
+const STORAGE_KEY = 'cloud_wallet_presentation_flow'
+
+const IDLE_STATE: PersistedPresentationState = { status: 'idle' }
+
+function isTerminalStatus(status: PresentationStatus): boolean {
+  return status === 'success' || status === 'error'
+}
+
+/** Only in-progress flow states are persisted (survives external redirects). */
+function isPersistableStatus(status: PresentationStatus): boolean {
+  return status !== 'idle' && !isTerminalStatus(status)
+}
+
+function isPresentationStatus(value: unknown): value is PresentationStatus {
+  return (
+    value === 'idle' ||
+    value === 'loading' ||
+    value === 'parsing' ||
+    value === 'verifying' ||
+    value === 'selecting' ||
+    value === 'reviewing' ||
+    value === 'consenting' ||
+    value === 'submitting' ||
+    value === 'success' ||
+    value === 'error'
+  )
+}
+
+function parsePersistedState(raw: string): PersistedPresentationState | null {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    const record = parsed as Record<string, unknown>
+    if (!isPresentationStatus(record.status)) return null
+    if (!isPersistableStatus(record.status)) return null
+    return parsed as PersistedPresentationState
+  } catch {
+    return null
+  }
+}
+
+function loadFromStorage(): PersistedPresentationState {
+  if (typeof window === 'undefined') {
+    return IDLE_STATE
+  }
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const recovered = parsePersistedState(stored)
+      if (recovered) return recovered
+    }
+  } catch {
+    // Ignore storage errors (e.g., private browsing mode)
+  }
+  return IDLE_STATE
+}
+
+function saveToStorage(state: PersistedPresentationState): void {
+  if (typeof window === 'undefined' || !isPersistableStatus(state.status)) {
+    return
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // Ignore storage errors (e.g., quota exceeded)
+  }
+}
+
+function removeFromStorage(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export type PresentationState = PersistedPresentationState & {
+  /** True while the flow is in progress (not idle, success, or error). */
+  isFlowActive: boolean
+  setStatus: (status: PresentationStatus) => void
+  setRequest: (request: ParsedPresentationRequest) => void
+  setVerifier: (verifier: VerifierMetadata) => void
+  setMatchingCredentials: (credentials: MatchingCredential[]) => void
+  setSelectedCredentials: (credentials: SelectedCredential[]) => void
+  setDisclosedClaims: (claims: DisclosedClaimMap) => void
+  setSubmissionResult: (result: PresentationResult) => void
+  setError: (error: PresentationError) => void
+  /** Reset all presentation state and remove persisted data. */
+  clear: () => void
+}
+
+const PresentationContext = createContext<PresentationState | null>(null)
+
+export function PresentationProvider({ children }: { children: React.ReactNode }) {
+  const [data, setData] = useState<PersistedPresentationState>(loadFromStorage)
+
+  useEffect(() => {
+    if (!isPersistableStatus(data.status)) {
+      removeFromStorage()
+      return
+    }
+    saveToStorage(data)
+  }, [data])
+
+  const setStatus = useCallback((status: PresentationStatus) => {
+    setData((prev) => {
+      if (status === 'success') {
+        return { ...prev, status: 'success', error: undefined }
+      }
+      return { ...prev, status }
+    })
+  }, [])
+
+  const setRequest = useCallback((request: ParsedPresentationRequest) => {
+    setData((prev) => ({ ...prev, request }))
+  }, [])
+
+  const setVerifier = useCallback((verifier: VerifierMetadata) => {
+    setData((prev) => ({ ...prev, verifier }))
+  }, [])
+
+  const setMatchingCredentials = useCallback(
+    (matchingCredentials: MatchingCredential[]) => {
+      setData((prev) => ({ ...prev, matchingCredentials }))
+    },
+    []
+  )
+
+  const setSelectedCredentials = useCallback(
+    (selectedCredentials: SelectedCredential[]) => {
+      setData((prev) => ({ ...prev, selectedCredentials }))
+    },
+    []
+  )
+
+  const setDisclosedClaims = useCallback((disclosedClaims: DisclosedClaimMap) => {
+    setData((prev) => ({ ...prev, disclosedClaims }))
+  }, [])
+
+  const setSubmissionResult = useCallback((submissionResult: PresentationResult) => {
+    setData((prev) => ({
+      ...prev,
+      submissionResult,
+      status: submissionResult.success ? 'success' : 'error',
+      error: submissionResult.success ? undefined : prev.error,
+    }))
+  }, [])
+
+  const setError = useCallback((error: PresentationError) => {
+    setData((prev) => ({
+      ...prev,
+      error,
+      status: 'error',
+      submissionResult: undefined,
+    }))
+  }, [])
+
+  const clear = useCallback(() => {
+    setData(IDLE_STATE)
+    removeFromStorage()
+  }, [])
+
+  useEffect(() => {
+    if (!isTerminalStatus(data.status)) return
+    clear()
+  }, [clear, data.status])
+
+  const isFlowActive =
+    data.status !== 'idle' && data.status !== 'success' && data.status !== 'error'
+
+  const value = useMemo<PresentationState>(
+    () => ({
+      ...data,
+      isFlowActive,
+      setStatus,
+      setRequest,
+      setVerifier,
+      setMatchingCredentials,
+      setSelectedCredentials,
+      setDisclosedClaims,
+      setSubmissionResult,
+      setError,
+      clear,
+    }),
+    [
+      clear,
+      data,
+      isFlowActive,
+      setDisclosedClaims,
+      setError,
+      setMatchingCredentials,
+      setRequest,
+      setSelectedCredentials,
+      setStatus,
+      setSubmissionResult,
+      setVerifier,
+    ]
+  )
+
+  return (
+    <PresentationContext.Provider value={value}>{children}</PresentationContext.Provider>
+  )
+}
+
+export function usePresentationState(): PresentationState {
+  const ctx = useContext(PresentationContext)
+  if (!ctx) {
+    throw new Error('usePresentationState must be used within PresentationProvider')
+  }
+  return ctx
+}

--- a/src/state/tests/presentation.state.test.tsx
+++ b/src/state/tests/presentation.state.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PresentationProvider, usePresentationState } from '../presentation.state'
+
+const STORAGE_KEY = 'cloud_wallet_presentation_flow'
+
+function PresentationProbe() {
+  const state = usePresentationState()
+  return (
+    <div>
+      <span data-testid="status">{state.status}</span>
+      <span data-testid="client-id">{state.verifier?.client_id ?? ''}</span>
+      <span data-testid="flow-active">{String(state.isFlowActive)}</span>
+      <button
+        type="button"
+        onClick={() => {
+          state.setStatus('selecting')
+          state.setVerifier({ client_id: 'redirect_uri:https://verifier.example/cb' })
+        }}
+      >
+        start
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          state.setSubmissionResult({
+            success: true,
+            redirect_uri: 'https://verifier.example/cb',
+          })
+        }
+      >
+        complete
+      </button>
+      <button
+        type="button"
+        onClick={() => state.setError({ code: 'user_rejected', message: 'Rejected' })}
+      >
+        fail
+      </button>
+      <button type="button" onClick={() => state.clear()}>
+        clear
+      </button>
+    </div>
+  )
+}
+
+function OutsideConsumer() {
+  usePresentationState()
+  return <div>outside</div>
+}
+
+describe('usePresentationState', () => {
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('throws when used outside provider', () => {
+    expect(() => render(<OutsideConsumer />)).toThrow(
+      'usePresentationState must be used within PresentationProvider'
+    )
+  })
+
+  it('provides default idle state inside provider', () => {
+    render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+    expect(screen.getByTestId('status').textContent).toBe('idle')
+    expect(screen.getByTestId('flow-active').textContent).toBe('false')
+  })
+
+  it('persists active flow to localStorage and recovers on remount', async () => {
+    const { unmount } = render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'start' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('selecting')
+    expect(screen.getByTestId('client-id').textContent).toBe(
+      'redirect_uri:https://verifier.example/cb'
+    )
+    expect(localStorage.getItem(STORAGE_KEY)).toContain('selecting')
+
+    unmount()
+
+    render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+
+    expect(screen.getByTestId('status').textContent).toBe('selecting')
+    expect(screen.getByTestId('client-id').textContent).toBe(
+      'redirect_uri:https://verifier.example/cb'
+    )
+    expect(screen.getByTestId('flow-active').textContent).toBe('true')
+  })
+
+  it('clear removes persisted state', async () => {
+    render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'start' }).click()
+    })
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'clear' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('idle')
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('auto-clears after successful completion without persisting terminal state', async () => {
+    render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'start' }).click()
+    })
+    expect(localStorage.getItem(STORAGE_KEY)).toContain('selecting')
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'complete' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('idle')
+    expect(screen.getByTestId('client-id').textContent).toBe('')
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('auto-clears after error without persisting terminal state', async () => {
+    render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'start' }).click()
+    })
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'fail' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('idle')
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('ignores legacy terminal state in localStorage on mount', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        status: 'success',
+        submissionResult: { success: true },
+        verifier: { client_id: 'stale-verifier' },
+      })
+    )
+
+    render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+
+    expect(screen.getByTestId('status').textContent).toBe('idle')
+    expect(screen.getByTestId('client-id').textContent).toBe('')
+  })
+})

--- a/src/state/tests/presentation.state.test.tsx
+++ b/src/state/tests/presentation.state.test.tsx
@@ -38,8 +38,110 @@ function PresentationProbe() {
       >
         fail
       </button>
+      <button type="button" onClick={() => state.setSubmissionResult({ success: false })}>
+        submit-fail
+      </button>
       <button type="button" onClick={() => state.clear()}>
         clear
+      </button>
+    </div>
+  )
+}
+
+function SetterProbe() {
+  const state = usePresentationState()
+  return (
+    <div>
+      <span data-testid="status">{state.status}</span>
+      <span data-testid="client-id">{state.request?.client_id ?? ''}</span>
+      <span data-testid="match-count">
+        {String(state.matchingCredentials?.length ?? 0)}
+      </span>
+      <span data-testid="selected-count">
+        {String(state.selectedCredentials?.length ?? 0)}
+      </span>
+      <span data-testid="disclosure-keys">
+        {Object.keys(state.disclosedClaims ?? {}).join(',')}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          state.setRequest({ client_id: 'verifier-client', response_type: 'vp_token' })
+        }
+      >
+        set-request
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          state.setMatchingCredentials([
+            {
+              credentialId: 'cred-1',
+              queryId: 'query-1',
+              format: 'dc+sd-jwt',
+            },
+          ])
+        }
+      >
+        set-matches
+      </button>
+      <button
+        type="button"
+        onClick={() => state.setDisclosedClaims({ 'cred-1': ['given_name'] })}
+      >
+        set-disclosures
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          state.setStatus('loading')
+          state.setStatus('parsing')
+          state.setStatus('selecting')
+        }}
+      >
+        advance-status
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          state.setMatchingCredentials([
+            { credentialId: 'cred-1', queryId: 'query-1', format: 'dc+sd-jwt' },
+          ])
+          state.setSelectedCredentials([
+            { credentialId: 'cred-1', queryId: 'query-1', format: 'dc+sd-jwt' },
+          ])
+          state.setDisclosedClaims({ 'cred-1': ['given_name'] })
+          state.setRequest({ client_id: 'new-request', response_type: 'vp_token' })
+        }}
+      >
+        new-request
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          state.setSelectedCredentials([
+            { credentialId: 'cred-1', queryId: 'query-1', format: 'dc+sd-jwt' },
+          ])
+          state.setDisclosedClaims({ 'cred-1': ['given_name'] })
+          state.setMatchingCredentials([
+            { credentialId: 'cred-2', queryId: 'query-2', format: 'dc+sd-jwt' },
+          ])
+        }}
+      >
+        refresh-matches
+      </button>
+    </div>
+  )
+}
+
+function SubmissionFailureProbe() {
+  const state = usePresentationState()
+  return (
+    <div>
+      <span data-testid="status">{state.status}</span>
+      <span data-testid="error-code">{state.error?.code ?? ''}</span>
+      <button type="button" onClick={() => state.setSubmissionResult({ success: false })}>
+        submit-fail
       </button>
     </div>
   )
@@ -124,7 +226,7 @@ describe('usePresentationState', () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
   })
 
-  it('auto-clears after successful completion without persisting terminal state', async () => {
+  it('keeps success state in memory until explicit clear and does not persist it', async () => {
     render(
       <PresentationProvider>
         <PresentationProbe />
@@ -140,12 +242,17 @@ describe('usePresentationState', () => {
       screen.getByRole('button', { name: 'complete' }).click()
     })
 
-    expect(screen.getByTestId('status').textContent).toBe('idle')
-    expect(screen.getByTestId('client-id').textContent).toBe('')
+    expect(screen.getByTestId('status').textContent).toBe('success')
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'clear' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('idle')
   })
 
-  it('auto-clears after error without persisting terminal state', async () => {
+  it('keeps error state in memory until explicit clear and does not persist it', async () => {
     render(
       <PresentationProvider>
         <PresentationProbe />
@@ -160,8 +267,14 @@ describe('usePresentationState', () => {
       screen.getByRole('button', { name: 'fail' }).click()
     })
 
-    expect(screen.getByTestId('status').textContent).toBe('idle')
+    expect(screen.getByTestId('status').textContent).toBe('error')
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'clear' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('idle')
   })
 
   it('ignores legacy terminal state in localStorage on mount', () => {
@@ -182,5 +295,128 @@ describe('usePresentationState', () => {
 
     expect(screen.getByTestId('status').textContent).toBe('idle')
     expect(screen.getByTestId('client-id').textContent).toBe('')
+  })
+
+  it('rejects persisted state with invalid verifier shape on mount', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        status: 'selecting',
+        verifier: { client_id: 12345 },
+      })
+    )
+
+    render(
+      <PresentationProvider>
+        <PresentationProbe />
+      </PresentationProvider>
+    )
+
+    expect(screen.getByTestId('status').textContent).toBe('idle')
+  })
+
+  it('stores parsed request via setRequest', async () => {
+    render(
+      <PresentationProvider>
+        <SetterProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'set-request' }).click()
+    })
+
+    expect(screen.getByTestId('client-id').textContent).toBe('verifier-client')
+  })
+
+  it('stores matching credentials via setMatchingCredentials', async () => {
+    render(
+      <PresentationProvider>
+        <SetterProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'set-matches' }).click()
+    })
+
+    expect(screen.getByTestId('match-count').textContent).toBe('1')
+  })
+
+  it('stores disclosure map via setDisclosedClaims', async () => {
+    render(
+      <PresentationProvider>
+        <SetterProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'set-disclosures' }).click()
+    })
+
+    expect(screen.getByTestId('disclosure-keys').textContent).toBe('cred-1')
+  })
+
+  it('advances status through multiple in-progress steps', async () => {
+    render(
+      <PresentationProvider>
+        <SetterProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'advance-status' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('selecting')
+    expect(localStorage.getItem(STORAGE_KEY)).toContain('selecting')
+  })
+
+  it('maps failed submission to submission_failed error', async () => {
+    render(
+      <PresentationProvider>
+        <SubmissionFailureProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'submit-fail' }).click()
+    })
+
+    expect(screen.getByTestId('status').textContent).toBe('error')
+    expect(screen.getByTestId('error-code').textContent).toBe('submission_failed')
+  })
+
+  it('setRequest clears credentials and results from a previous flow', async () => {
+    render(
+      <PresentationProvider>
+        <SetterProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'new-request' }).click()
+    })
+
+    expect(screen.getByTestId('client-id').textContent).toBe('new-request')
+    expect(screen.getByTestId('match-count').textContent).toBe('0')
+    expect(screen.getByTestId('selected-count').textContent).toBe('0')
+    expect(screen.getByTestId('disclosure-keys').textContent).toBe('')
+  })
+
+  it('setMatchingCredentials clears prior selection and disclosures', async () => {
+    render(
+      <PresentationProvider>
+        <SetterProbe />
+      </PresentationProvider>
+    )
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'refresh-matches' }).click()
+    })
+
+    expect(screen.getByTestId('match-count').textContent).toBe('1')
+    expect(screen.getByTestId('selected-count').textContent).toBe('0')
+    expect(screen.getByTestId('disclosure-keys').textContent).toBe('')
   })
 })

--- a/src/types/presentation.ts
+++ b/src/types/presentation.ts
@@ -1,0 +1,130 @@
+import type { CredentialFormat } from './credential'
+
+/**
+ * Lifecycle status for the OpenID4VP presentation flow.
+ * @see https://openid.net/specs/openid-4-verifiable-presentations-1_0.html
+ */
+export type PresentationStatus =
+  | 'idle'
+  | 'loading'
+  | 'parsing'
+  | 'verifying'
+  | 'selecting'
+  | 'reviewing'
+  | 'consenting'
+  | 'submitting'
+  | 'success'
+  | 'error'
+
+/** Verifier-facing metadata resolved from client_id and client_metadata. */
+export type VerifierMetadata = {
+  client_id: string
+  client_metadata?: Record<string, unknown>
+  name?: string
+  logo_uri?: string
+}
+
+/** Claims path pointer per OID4VP §7 (JSON-based credentials). */
+export type ClaimsPathPointer = (string | number | null)[]
+
+export type DcqlClaimQuery = {
+  id?: string
+  path: ClaimsPathPointer
+  values?: unknown[]
+}
+
+export type DcqlCredentialQuery = {
+  id: string
+  format: string
+  meta?: Record<string, unknown>
+  claims?: DcqlClaimQuery[]
+  claim_sets?: string[][]
+  trusted_authorities?: unknown[]
+  require_cryptographic_holder_binding?: boolean
+}
+
+export type DcqlCredentialSetQuery = {
+  options: string[][]
+  required?: boolean
+}
+
+/** DCQL query from the dcql_query authorization request parameter. */
+export type DcqlQuery = {
+  credentials: DcqlCredentialQuery[]
+  credential_sets?: DcqlCredentialSetQuery[]
+}
+
+/**
+ * Normalized presentation authorization request after parsing
+ * (authorization request or signed request object).
+ */
+export type ParsedPresentationRequest = {
+  response_type?: string
+  response_mode?: string
+  client_id?: string
+  scope?: string
+  dcql_query?: DcqlQuery
+  state?: string
+  nonce?: string
+  request_uri?: string
+  request_uri_method?: string
+  presentation_definition?: Record<string, unknown>
+  presentation_definition_uri?: string
+  [key: string]: unknown
+}
+
+/** Wallet credential that satisfies a DCQL credential query. */
+export type MatchingCredential = {
+  credentialId: string
+  queryId: string
+  format: CredentialFormat | string
+  displayName?: string
+}
+
+/** Credential chosen by the holder for presentation. */
+export type SelectedCredential = {
+  credentialId: string
+  queryId: string
+  format: CredentialFormat | string
+}
+
+/** Maps wallet credential ID → selected claim ids/paths for selective disclosure. */
+export type DisclosedClaimMap = Record<string, string[]>
+
+export type PresentationResult = {
+  success: boolean
+  redirect_uri?: string
+  state?: string
+}
+
+export type PresentationErrorCode =
+  | 'invalid_request'
+  | 'invalid_presentation_request'
+  | 'session_not_found'
+  | 'invalid_session_state'
+  | 'verifier_metadata_fetch_failed'
+  | 'no_matching_credentials'
+  | 'user_rejected'
+  | 'submission_failed'
+  | 'unauthorized'
+  | 'internal_error'
+  | (string & Record<never, never>)
+
+export type PresentationError = {
+  httpStatus?: number
+  code: PresentationErrorCode
+  message: string
+  error_description?: string | null
+}
+
+/** Serializable presentation flow data persisted to localStorage. */
+export type PersistedPresentationState = {
+  status: PresentationStatus
+  request?: ParsedPresentationRequest
+  verifier?: VerifierMetadata
+  matchingCredentials?: MatchingCredential[]
+  selectedCredentials?: SelectedCredential[]
+  disclosedClaims?: DisclosedClaimMap
+  submissionResult?: PresentationResult
+  error?: PresentationError
+}


### PR DESCRIPTION
Create centralized state management for the entire presentation process using React Context, following the pattern established by `CredentialOfferProvider`.

The state store must persist across page transitions and handle the complete presentation lifecycle from request parsing through submission result.

### Tasks
- [ ] Create `PresentationProvider` context (`src/state/presentation.state.tsx`)
- [ ] Define `PresentationState` interface with status machine
- [ ] Store verifier metadata (client_id, client_metadata, logo, name)
- [ ] Store parsed presentation request (DCQL query or scope)
- [ ] Store selected credentials with format information
- [ ] Store disclosure decisions per credential (selective disclosure choices)
- [ ] Store submission result (success/failure details)
- [ ] Implement `clear()` to reset state after flow completion
- [ ] Add localStorage persistence for resilience during external redirects
- [ ] Implement state recovery on page reload

### State Interface
```typescript
interface PresentationState {
  status: 'idle' | 'loading' | 'parsing' | 'verifying' | 'selecting' | 'reviewing' | 'consenting' | 'submitting' | 'success' | 'error'
  request?: ParsedPresentationRequest
  verifier?: VerifierMetadata
  matchingCredentials?: MatchingCredential[]
  selectedCredentials?: SelectedCredential[]
  disclosedClaims?: DisclosedClaimMap
  submissionResult?: PresentationResult
  error?: PresentationError
}
```

### Acceptance Criteria
- State is accessible across all presentation screens via `usePresentationState()` hook
- State survives page transitions and browser reloads
- State is automatically cleared after flow completion or on explicit cancel
- No stale presentation data remains after flow completion
- Follows existing `CredentialOfferProvider` patterns for consistency

### Tests
- [x] All tests passed  from `npm run test`