### PR TITLE
chore: remove Playwright E2E job from UI CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,26 +39,3 @@ jobs:
 
       - name: Build
         run: npm run build
-
-  e2e:
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      - name: Run E2E tests
-        run: npm run test:e2e


### PR DESCRIPTION


### Summary

- Remove the `e2e` job from `.github/workflows/ci.yml`
- CI still runs format, lint, unit tests, and build
- E2E tests remain in the repo (`e2e/`, `npm run test:e2e`) but are no longer run in GitHub Actions

### Test plan

- [ ] CI passes on this PR (style job only)
- [ ] `npm run test:e2e` still works locally if needed

Closes https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/97