### PR TITLE
feat: implement presentation request flow with error handling and validation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { CredentialsCacheProvider } from './state/credentialsCache.state'
 import { CredentialTypesPage } from './pages/CredentialTypesPage'
 import { IssuanceSuccessPage } from './pages/IssuanceSuccessPage'
 import { RegistrationPage } from './pages/RegistrationPage'
+import { PresentationRequestPage } from './pages/presentation/PresentationRequestPage'
 import { getStoredTenantId } from './auth/tenant'
 
 function RequireRegistration({ children }: { children: ReactNode }) {
@@ -53,6 +54,14 @@ function App() {
                 element={
                   <RequireRegistration>
                     <ScanPage />
+                  </RequireRegistration>
+                }
+              />
+              <Route
+                path={routes.present}
+                element={
+                  <RequireRegistration>
+                    <PresentationRequestPage />
                   </RequireRegistration>
                 }
               />

--- a/src/api/presentation/errors.ts
+++ b/src/api/presentation/errors.ts
@@ -1,0 +1,24 @@
+import type { PresentationErrorCode } from '../../types/presentation'
+
+/**
+ * Structured error thrown when the backend returns a non-2xx response for
+ * presentation endpoints.
+ */
+export class PresentationError extends Error {
+  public readonly httpStatus: number
+  public readonly code: PresentationErrorCode
+  public readonly error_description: string | null
+
+  constructor(error: {
+    httpStatus: number
+    code: PresentationErrorCode
+    message: string
+    error_description?: string | null
+  }) {
+    super(error.message)
+    this.name = 'PresentationError'
+    this.httpStatus = error.httpStatus
+    this.code = error.code
+    this.error_description = error.error_description ?? null
+  }
+}

--- a/src/api/presentation/start.ts
+++ b/src/api/presentation/start.ts
@@ -1,0 +1,28 @@
+import { apiPost } from '../client'
+import type {
+  StartPresentationRequest,
+  StartPresentationResponse,
+} from '../../types/presentation'
+import { validateStartPresentationResponse } from './validation'
+
+export { PresentationError } from './errors'
+
+/**
+ * Start an OpenID4VP presentation session.
+ *
+ * Spec: POST /presentation/start
+ * Request:  StartPresentationRequest
+ * Response: StartPresentationResponse
+ *
+ * The response is validated against the API contract before being returned.
+ * A `ContractError` is thrown if the backend response does not conform.
+ */
+export async function startPresentation(
+  authorization: StartPresentationRequest
+): Promise<StartPresentationResponse> {
+  const raw = await apiPost<unknown, StartPresentationRequest>(
+    '/presentation/start',
+    authorization
+  )
+  return validateStartPresentationResponse(raw)
+}

--- a/src/api/presentation/tests/validation.test.ts
+++ b/src/api/presentation/tests/validation.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { ContractError } from '../../validation'
+import { validateStartPresentationResponse } from '../validation'
+
+const validRequest = {
+  client_id: 'https://verifier.example',
+  nonce: 'nonce-123',
+  response_type: 'vp_token',
+  response_mode: 'direct_post',
+  dcql_query: {
+    credentials: [{ id: 'identity', format: 'dc+sd-jwt' }],
+  },
+}
+
+const validResponse = {
+  request: validRequest,
+  verifier: {
+    client_id: 'https://verifier.example',
+    name: 'Keycloak-demo',
+    logo_uri: 'https://verifier.example/logo.png',
+  },
+  matching_credentials: [
+    {
+      credentialId: 'cred-1',
+      queryId: 'identity',
+      format: 'dc+sd-jwt',
+      displayName: 'Identity Credential',
+    },
+  ],
+}
+
+describe('validateStartPresentationResponse', () => {
+  it('accepts a valid response', () => {
+    const result = validateStartPresentationResponse(validResponse)
+    expect(result.request.nonce).toBe('nonce-123')
+    expect(result.verifier.name).toBe('Keycloak-demo')
+    expect(result.matching_credentials).toHaveLength(1)
+  })
+
+  it('accepts scope instead of dcql_query', () => {
+    const result = validateStartPresentationResponse({
+      ...validResponse,
+      request: {
+        client_id: validRequest.client_id,
+        nonce: validRequest.nonce,
+        response_type: validRequest.response_type,
+        response_mode: validRequest.response_mode,
+        scope: 'openid',
+      },
+    })
+    expect(result.request.scope).toBe('openid')
+  })
+
+  it('accepts an empty matching_credentials array', () => {
+    const result = validateStartPresentationResponse({
+      ...validResponse,
+      matching_credentials: [],
+    })
+    expect(result.matching_credentials).toEqual([])
+  })
+
+  it('throws ContractError when request.nonce is missing', () => {
+    expect(() =>
+      validateStartPresentationResponse({
+        ...validResponse,
+        request: {
+          client_id: validRequest.client_id,
+          response_type: validRequest.response_type,
+          response_mode: validRequest.response_mode,
+          dcql_query: validRequest.dcql_query,
+        },
+      })
+    ).toThrow(ContractError)
+  })
+
+  it('throws ContractError when request has neither scope nor dcql_query', () => {
+    expect(() =>
+      validateStartPresentationResponse({
+        ...validResponse,
+        request: {
+          client_id: validRequest.client_id,
+          nonce: validRequest.nonce,
+          response_type: validRequest.response_type,
+          response_mode: validRequest.response_mode,
+        },
+      })
+    ).toThrow(ContractError)
+  })
+
+  it('throws ContractError when verifier.client_id is missing', () => {
+    expect(() =>
+      validateStartPresentationResponse({
+        ...validResponse,
+        verifier: { name: 'Verifier' },
+      })
+    ).toThrow(ContractError)
+  })
+
+  it('throws ContractError when matching credential is missing credentialId', () => {
+    expect(() =>
+      validateStartPresentationResponse({
+        ...validResponse,
+        matching_credentials: [{ queryId: 'identity', format: 'dc+sd-jwt' }],
+      })
+    ).toThrow(ContractError)
+  })
+
+  it('throws ContractError when response is null', () => {
+    expect(() => validateStartPresentationResponse(null)).toThrow(ContractError)
+  })
+})

--- a/src/api/presentation/validation.ts
+++ b/src/api/presentation/validation.ts
@@ -1,0 +1,181 @@
+import type {
+  DcqlQuery,
+  MatchingCredential,
+  ParsedPresentationRequest,
+  StartPresentationResponse,
+  VerifierMetadata,
+} from '../../types/presentation'
+import { ContractError } from '../validation'
+
+const SUPPORTED_RESPONSE_TYPES = new Set(['vp_token', 'vp_token id_token'])
+const SUPPORTED_RESPONSE_MODES = new Set([
+  'direct_post',
+  'direct_post.jwt',
+  'fragment',
+  'query',
+])
+
+function requireString(ctx: string, field: string, value: unknown): string {
+  if (typeof value !== 'string') throw new ContractError(ctx, field, value)
+  return value
+}
+
+function requireObject(
+  ctx: string,
+  field: string,
+  value: unknown
+): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    throw new ContractError(ctx, field, value)
+  return value as Record<string, unknown>
+}
+
+function requireArray(ctx: string, field: string, value: unknown): unknown[] {
+  if (!Array.isArray(value)) throw new ContractError(ctx, field, value)
+  return value
+}
+
+function validateVerifierMetadata(raw: unknown): VerifierMetadata {
+  const ctx = 'StartPresentationResponse.verifier'
+  const obj = requireObject(ctx, 'verifier', raw)
+  const client_id = requireString(ctx, 'client_id', obj.client_id)
+
+  const name = obj.name === undefined ? undefined : requireString(ctx, 'name', obj.name)
+  const logo_uri =
+    obj.logo_uri === undefined ? undefined : requireString(ctx, 'logo_uri', obj.logo_uri)
+
+  return {
+    client_id,
+    ...(name !== undefined ? { name } : {}),
+    ...(logo_uri !== undefined ? { logo_uri } : {}),
+    ...(obj.client_metadata !== undefined
+      ? { client_metadata: obj.client_metadata as Record<string, unknown> }
+      : {}),
+  }
+}
+
+function validateMatchingCredential(raw: unknown, index: number): MatchingCredential {
+  const ctx = `StartPresentationResponse.matching_credentials[${index}]`
+  const obj = requireObject(ctx, 'matching_credentials[]', raw)
+
+  const credentialId = requireString(ctx, 'credentialId', obj.credentialId)
+  const queryId = requireString(ctx, 'queryId', obj.queryId)
+  const format = requireString(ctx, 'format', obj.format)
+  const displayName =
+    obj.displayName === undefined
+      ? undefined
+      : requireString(ctx, 'displayName', obj.displayName)
+
+  return {
+    credentialId,
+    queryId,
+    format,
+    ...(displayName !== undefined ? { displayName } : {}),
+  }
+}
+
+function validateDcqlQuery(raw: unknown): DcqlQuery {
+  const ctx = 'StartPresentationResponse.request.dcql_query'
+  const obj = requireObject(ctx, 'dcql_query', raw)
+  const credentials = requireArray(ctx, 'credentials', obj.credentials)
+  if (credentials.length === 0) {
+    throw new ContractError(ctx, 'credentials', credentials)
+  }
+  return obj as DcqlQuery
+}
+
+/**
+ * Validate the resolved OID4VP Authorization Request (§5.2 required fields).
+ */
+function validateParsedPresentationRequest(raw: unknown): ParsedPresentationRequest {
+  const ctx = 'StartPresentationResponse.request'
+  const obj = requireObject(ctx, 'request', raw)
+
+  const client_id = requireString(ctx, 'client_id', obj.client_id)
+  const nonce = requireString(ctx, 'nonce', obj.nonce)
+  const response_type = requireString(ctx, 'response_type', obj.response_type)
+  const response_mode = requireString(ctx, 'response_mode', obj.response_mode)
+
+  if (!SUPPORTED_RESPONSE_TYPES.has(response_type)) {
+    throw new ContractError(ctx, 'response_type', response_type)
+  }
+  if (!SUPPORTED_RESPONSE_MODES.has(response_mode)) {
+    throw new ContractError(ctx, 'response_mode', response_mode)
+  }
+
+  const scope =
+    obj.scope === undefined ? undefined : requireString(ctx, 'scope', obj.scope)
+  const dcql_query =
+    obj.dcql_query === undefined ? undefined : validateDcqlQuery(obj.dcql_query)
+
+  if (!scope && !dcql_query) {
+    throw new ContractError(ctx, 'dcql_query', obj.dcql_query ?? obj.scope)
+  }
+  if (scope && dcql_query) {
+    throw new ContractError(ctx, 'scope', scope)
+  }
+
+  const state =
+    obj.state === undefined ? undefined : requireString(ctx, 'state', obj.state)
+  const request_uri =
+    obj.request_uri === undefined
+      ? undefined
+      : requireString(ctx, 'request_uri', obj.request_uri)
+  const request_uri_method =
+    obj.request_uri_method === undefined
+      ? undefined
+      : requireString(ctx, 'request_uri_method', obj.request_uri_method)
+
+  const request: ParsedPresentationRequest = {
+    client_id,
+    nonce,
+    response_type,
+    response_mode,
+    ...(scope !== undefined ? { scope } : {}),
+    ...(dcql_query !== undefined ? { dcql_query } : {}),
+    ...(state !== undefined ? { state } : {}),
+    ...(request_uri !== undefined ? { request_uri } : {}),
+    ...(request_uri_method !== undefined ? { request_uri_method } : {}),
+  }
+
+  if (obj.presentation_definition !== undefined) {
+    request.presentation_definition = requireObject(
+      ctx,
+      'presentation_definition',
+      obj.presentation_definition
+    )
+  }
+  if (obj.presentation_definition_uri !== undefined) {
+    request.presentation_definition_uri = requireString(
+      ctx,
+      'presentation_definition_uri',
+      obj.presentation_definition_uri
+    )
+  }
+
+  return request
+}
+
+/**
+ * Validate POST /presentation/start response against the wallet API contract.
+ */
+export function validateStartPresentationResponse(
+  raw: unknown
+): StartPresentationResponse {
+  const ctx = 'StartPresentationResponse'
+  const obj = requireObject(ctx, 'response', raw)
+
+  const request = validateParsedPresentationRequest(obj.request)
+  const verifier = validateVerifierMetadata(obj.verifier)
+  const rawCredentials = requireArray(
+    ctx,
+    'matching_credentials',
+    obj.matching_credentials
+  )
+
+  const matching_credentials = rawCredentials.map((entry, index) =>
+    validateMatchingCredential(entry, index)
+  )
+
+  return { request, verifier, matching_credentials }
+}

--- a/src/components/presentation/PresentationErrorCard.tsx
+++ b/src/components/presentation/PresentationErrorCard.tsx
@@ -1,0 +1,41 @@
+import illuWallet from '../../assets/illu-wallet.png'
+import type { PresentationError } from '../../types/presentation'
+import { presentationUserMessage } from '../../utils/presentation/presentationErrors'
+
+type PresentationErrorCardProps = {
+  error: PresentationError
+  onRetry?: () => void
+  retryLabel?: string
+}
+
+export function PresentationErrorCard({
+  error,
+  onRetry,
+  retryLabel = 'Try again',
+}: PresentationErrorCardProps) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center px-6 py-16 text-center">
+      <div className="relative mb-12 h-52 w-52">
+        <div className="absolute inset-0 rounded-full ring-[6px] ring-transparent" />
+        <div className="absolute inset-0 animate-spin rounded-full border-[8px] border-[#99e827] border-t-transparent border-r-transparent" />
+        <img
+          src={illuWallet}
+          alt=""
+          className="absolute inset-8 m-auto h-[calc(100%-4rem)] w-[calc(100%-4rem)] object-contain"
+        />
+      </div>
+      <p className="max-w-md whitespace-pre-line text-base text-slate-700">
+        {presentationUserMessage(error)}
+      </p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-6 rounded-lg bg-[#99e827] px-8 py-2.5 text-base font-medium text-black shadow transition-colors hover:bg-[#66b80f] active:bg-[#5aa70d]"
+        >
+          {retryLabel}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/presentation/PresentationLoadingState.tsx
+++ b/src/components/presentation/PresentationLoadingState.tsx
@@ -1,0 +1,24 @@
+import illuWallet from '../../assets/illu-wallet.png'
+
+type PresentationLoadingStateProps = {
+  message?: string
+}
+
+export function PresentationLoadingState({
+  message = 'Processing proof request…',
+}: PresentationLoadingStateProps) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center px-6 py-16 text-center">
+      <div className="relative mb-12 h-52 w-52">
+        <div className="absolute inset-0 rounded-full ring-[6px] ring-transparent" />
+        <div className="absolute inset-0 animate-spin rounded-full border-[8px] border-[#99e827] border-t-transparent border-r-transparent" />
+        <img
+          src={illuWallet}
+          alt=""
+          className="absolute inset-8 m-auto h-[calc(100%-4rem)] w-[calc(100%-4rem)] object-contain"
+        />
+      </div>
+      <p className="text-base text-slate-700">{message}</p>
+    </div>
+  )
+}

--- a/src/components/presentation/PresentationPageShell.tsx
+++ b/src/components/presentation/PresentationPageShell.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Footer } from '../Footer'
+import { PageContainer } from '../layout/PageContainer'
+import { routes } from '../../constants/routes'
+
+type PresentationPageShellProps = {
+  title: string
+  onBack: () => void
+  children: ReactNode
+}
+
+/**
+ * Shared layout for presentation flow screens — matches issuance credential
+ * pages (gradient bar header + bottom nav), without the global PWA Header.
+ */
+export function PresentationPageShell({
+  title,
+  onBack,
+  children,
+}: PresentationPageShellProps) {
+  const navigate = useNavigate()
+
+  return (
+    <PageContainer fullWidth>
+      <div className="flex min-h-screen w-full flex-col overflow-hidden rounded-none bg-[#e9ecef] font-serif">
+        <div className="grid grid-cols-[auto_1fr_auto] items-center border-b border-[#96a8b2] bg-gradient-to-r from-[#3f6f7e] to-[#4e7f8f] px-2 py-2">
+          <button
+            type="button"
+            onClick={onBack}
+            className="h-10 w-10 rounded-full text-3xl leading-none text-white"
+            aria-label="Back"
+          >
+            ‹
+          </button>
+          <div className="text-center text-[16px] font-semibold leading-none text-white md:text-[18px]">
+            {title}
+          </div>
+          <div className="w-10" />
+        </div>
+
+        {children}
+
+        <Footer
+          activeTab="creds"
+          onScanClick={() => navigate(`${routes.scan}?fresh=true`)}
+          scanDisabled={false}
+        />
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,6 +2,7 @@ export const routes = {
   registration: '/registration',
   home: '/',
   scan: '/scan',
+  present: '/present',
   credentialTypes: '/credential-types',
   credentialTypeDetails: '/credential-types/:optionId',
   credentials: '/credentials',

--- a/src/hooks/presentation/usePresentationSession.test.tsx
+++ b/src/hooks/presentation/usePresentationSession.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { PresentationError, startPresentation } from '../../api/presentation/start'
+import { PresentationProvider } from '../../state/presentation.state'
+import { usePresentationSession } from './usePresentationSession'
+
+vi.mock('../../api/presentation/start', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/presentation/start')>()
+  return {
+    ...actual,
+    startPresentation: vi.fn(),
+  }
+})
+
+const mockedStartPresentation = vi.mocked(startPresentation)
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <PresentationProvider>{children}</PresentationProvider>
+}
+
+const authorization = {
+  client_id: 'https://verifier.example',
+  request_uri: 'https://verifier.example/request',
+  response_type: 'vp_token',
+  nonce: 'nonce-123',
+  scope: 'openid',
+}
+
+describe('usePresentationSession', () => {
+  it('stores parsed presentation data on success', async () => {
+    mockedStartPresentation.mockResolvedValueOnce({
+      request: {
+        client_id: authorization.client_id,
+        nonce: authorization.nonce ?? 'nonce-123',
+        response_type: 'vp_token',
+        response_mode: 'direct_post',
+        scope: authorization.scope,
+      },
+      verifier: { client_id: authorization.client_id, name: 'Keycloak-demo' },
+      matching_credentials: [
+        {
+          credentialId: 'cred-1',
+          queryId: 'identity',
+          format: 'dc+sd-jwt',
+          displayName: 'Identity Credential',
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => usePresentationSession(), { wrapper })
+
+    await act(async () => {
+      await result.current.startRequest(authorization)
+    })
+
+    await waitFor(() => {
+      expect(result.current.sessionState.status).toBe('success')
+    })
+  })
+
+  it('surfaces contract validation errors', async () => {
+    const { ContractError } = await import('../../api/validation')
+    mockedStartPresentation.mockRejectedValueOnce(
+      new ContractError('StartPresentationResponse', 'verifier', null)
+    )
+
+    const { result } = renderHook(() => usePresentationSession(), { wrapper })
+
+    await act(async () => {
+      await result.current.startRequest(authorization)
+    })
+
+    expect(result.current.sessionState.status).toBe('error')
+    if (result.current.sessionState.status === 'error') {
+      expect(result.current.sessionState.error.code).toBe('internal_error')
+    }
+  })
+
+  it('surfaces API errors', async () => {
+    mockedStartPresentation.mockRejectedValueOnce(
+      new PresentationError({
+        httpStatus: 400,
+        code: 'invalid_presentation_request',
+        message: 'Invalid request',
+      })
+    )
+
+    const { result } = renderHook(() => usePresentationSession(), { wrapper })
+
+    await act(async () => {
+      await result.current.startRequest(authorization)
+    })
+
+    expect(result.current.sessionState.status).toBe('error')
+    if (result.current.sessionState.status === 'error') {
+      expect(result.current.sessionState.error.code).toBe('invalid_presentation_request')
+    }
+  })
+})

--- a/src/hooks/presentation/usePresentationSession.ts
+++ b/src/hooks/presentation/usePresentationSession.ts
@@ -29,6 +29,10 @@ export function usePresentationSession(): UsePresentationSessionReturn {
 
   const startRequest = useCallback(
     async (authorization: PresentationAuthorizationRequest) => {
+      if (presentation.status === 'loading') {
+        return
+      }
+
       setSessionState({ status: 'loading' })
       presentation.clear()
       presentation.setStatus('loading')

--- a/src/hooks/presentation/usePresentationSession.ts
+++ b/src/hooks/presentation/usePresentationSession.ts
@@ -1,0 +1,58 @@
+import { useCallback, useState } from 'react'
+import { startPresentation } from '../../api/presentation/start'
+import { usePresentationState } from '../../state/presentation.state'
+import type {
+  PresentationAuthorizationRequest,
+  PresentationError,
+} from '../../types/presentation'
+import { toPresentationError } from '../../utils/presentation/presentationErrors.ts'
+
+export type PresentationSessionState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success' }
+  | { status: 'error'; error: PresentationError }
+
+export type UsePresentationSessionReturn = {
+  sessionState: PresentationSessionState
+  /** Validate and submit an OpenID4VP authorization request to the wallet backend. */
+  startRequest: (authorization: PresentationAuthorizationRequest) => Promise<void>
+  reset: () => void
+}
+
+export function usePresentationSession(): UsePresentationSessionReturn {
+  const [sessionState, setSessionState] = useState<PresentationSessionState>({
+    status: 'idle',
+  })
+
+  const presentation = usePresentationState()
+
+  const startRequest = useCallback(
+    async (authorization: PresentationAuthorizationRequest) => {
+      setSessionState({ status: 'loading' })
+      presentation.clear()
+      presentation.setStatus('loading')
+
+      try {
+        const response = await startPresentation(authorization)
+        presentation.setRequest(response.request)
+        presentation.setVerifier(response.verifier)
+        presentation.setMatchingCredentials(response.matching_credentials)
+        presentation.setStatus('selecting')
+        setSessionState({ status: 'success' })
+      } catch (error: unknown) {
+        const apiError = toPresentationError(error)
+        presentation.setError(apiError)
+        setSessionState({ status: 'error', error: apiError })
+      }
+    },
+    [presentation]
+  )
+
+  const reset = useCallback(() => {
+    setSessionState({ status: 'idle' })
+    presentation.clear()
+  }, [presentation])
+
+  return { sessionState, startRequest, reset }
+}

--- a/src/pages/ScanPage.tsx
+++ b/src/pages/ScanPage.tsx
@@ -9,6 +9,7 @@ import { useIssuanceSession } from '../hooks/useIssuanceSession'
 import type { IssuanceApiError } from '../types/issuance'
 import { issuanceUserMessage } from '../utils/issuanceErrors'
 import { parseCredentialOfferInput } from '../utils/credentialOffer'
+import { parsePresentationScanInput } from '../utils/presentation/presentationScanInput'
 import illuWallet from '../assets/illu-wallet.png'
 import { E2E_SCAN_SAMPLE_OFFER } from '../e2e/scan-sample-offer'
 
@@ -67,6 +68,14 @@ export function ScanPage() {
 
       const parsedOffer = parseCredentialOfferInput(value)
       if (!parsedOffer) {
+        const presentationPath = parsePresentationScanInput(value)
+        if (presentationPath) {
+          setScanStatus('done')
+          scanInProgressRef.current = false
+          navigate(presentationPath)
+          return
+        }
+
         const apiError: IssuanceApiError = {
           httpStatus: 400,
           error: 'invalid_credential_offer',
@@ -89,7 +98,7 @@ export function ScanPage() {
       setScanStatus('done')
       scanInProgressRef.current = false
     },
-    [stopScanner, submitOffer]
+    [navigate, stopScanner, submitOffer]
   )
 
   useEffect(() => {

--- a/src/pages/presentation/PresentationRequestPage.tsx
+++ b/src/pages/presentation/PresentationRequestPage.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { PresentationErrorCard } from '../../components/presentation/PresentationErrorCard'
+import { PresentationLoadingState } from '../../components/presentation/PresentationLoadingState'
+import { PresentationPageShell } from '../../components/presentation/PresentationPageShell'
+import { routes } from '../../constants/routes'
+import { usePresentationSession } from '../../hooks/presentation/usePresentationSession'
+import { parsePresentationRequestParams } from '../../utils/presentation/presentationRequest'
+
+export function PresentationRequestPage() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { sessionState, startRequest, reset } = usePresentationSession()
+  const hasStartedRef = useRef(false)
+
+  const parsedParams = useMemo(
+    () => parsePresentationRequestParams(searchParams),
+    [searchParams]
+  )
+
+  useEffect(() => {
+    if (!parsedParams.ok || hasStartedRef.current) {
+      return
+    }
+    hasStartedRef.current = true
+    void startRequest(parsedParams.authorization)
+  }, [parsedParams, startRequest])
+
+  const handleBack = () => {
+    reset()
+    navigate(routes.home)
+  }
+
+  const handleRetry = () => {
+    if (!parsedParams.ok) {
+      navigate(routes.scan)
+      return
+    }
+    hasStartedRef.current = false
+    reset()
+    hasStartedRef.current = true
+    void startRequest(parsedParams.authorization)
+  }
+
+  return (
+    <PresentationPageShell title="Proof Request" onBack={handleBack}>
+      <section className="flex flex-1 flex-col">
+        {!parsedParams.ok && (
+          <PresentationErrorCard
+            error={parsedParams.error}
+            onRetry={() => navigate(routes.scan)}
+            retryLabel="Scan QR code"
+          />
+        )}
+
+        {parsedParams.ok && sessionState.status === 'loading' && (
+          <PresentationLoadingState />
+        )}
+
+        {parsedParams.ok && sessionState.status === 'error' && (
+          <PresentationErrorCard error={sessionState.error} onRetry={handleRetry} />
+        )}
+      </section>
+    </PresentationPageShell>
+  )
+}

--- a/src/pages/presentation/PresentationRequestPage.tsx
+++ b/src/pages/presentation/PresentationRequestPage.tsx
@@ -1,17 +1,18 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { PresentationErrorCard } from '../../components/presentation/PresentationErrorCard'
 import { PresentationLoadingState } from '../../components/presentation/PresentationLoadingState'
 import { PresentationPageShell } from '../../components/presentation/PresentationPageShell'
 import { routes } from '../../constants/routes'
 import { usePresentationSession } from '../../hooks/presentation/usePresentationSession'
+import { usePresentationState } from '../../state/presentation.state'
 import { parsePresentationRequestParams } from '../../utils/presentation/presentationRequest'
 
 export function PresentationRequestPage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const { sessionState, startRequest, reset } = usePresentationSession()
-  const hasStartedRef = useRef(false)
+  const presentation = usePresentationState()
 
   const parsedParams = useMemo(
     () => parsePresentationRequestParams(searchParams),
@@ -19,12 +20,18 @@ export function PresentationRequestPage() {
   )
 
   useEffect(() => {
-    if (!parsedParams.ok || hasStartedRef.current) {
+    if (!parsedParams.ok) {
       return
     }
-    hasStartedRef.current = true
+
+    const flowAlreadyStarted =
+      presentation.status !== 'idle' && presentation.status !== 'error'
+    if (flowAlreadyStarted || sessionState.status === 'loading') {
+      return
+    }
+
     void startRequest(parsedParams.authorization)
-  }, [parsedParams, startRequest])
+  }, [parsedParams, presentation.status, sessionState.status, startRequest])
 
   const handleBack = () => {
     reset()
@@ -36,9 +43,7 @@ export function PresentationRequestPage() {
       navigate(routes.scan)
       return
     }
-    hasStartedRef.current = false
     reset()
-    hasStartedRef.current = true
     void startRequest(parsedParams.authorization)
   }
 

--- a/src/pages/presentation/tests/PresentationRequestPage.test.tsx
+++ b/src/pages/presentation/tests/PresentationRequestPage.test.tsx
@@ -12,6 +12,7 @@ const mockStartRequest = vi.fn()
 const mockReset = vi.fn()
 
 let mockSessionState: PresentationSessionState = { status: 'idle' }
+let mockPresentationStatus = 'idle'
 
 vi.mock('react-router-dom', async () => {
   const actual =
@@ -24,6 +25,12 @@ vi.mock('../../../hooks/presentation/usePresentationSession', () => ({
     sessionState: mockSessionState,
     startRequest: mockStartRequest,
     reset: mockReset,
+  }),
+}))
+
+vi.mock('../../../state/presentation.state', () => ({
+  usePresentationState: () => ({
+    status: mockPresentationStatus,
   }),
 }))
 
@@ -72,6 +79,7 @@ describe('PresentationRequestPage', () => {
     mockStartRequest.mockReset()
     mockReset.mockReset()
     mockSessionState = { status: 'idle' }
+    mockPresentationStatus = 'idle'
   })
 
   it('shows validation error when query params are missing', () => {
@@ -116,14 +124,13 @@ describe('PresentationRequestPage', () => {
     expect(mockStartRequest).toHaveBeenCalled()
   })
 
-  it('does not navigate away on success', async () => {
-    mockSessionState = { status: 'success' }
+  it('does not start a duplicate request when the flow is already in progress', async () => {
+    mockPresentationStatus = 'loading'
     renderPage()
 
     await waitFor(() => {
-      expect(mockStartRequest).toHaveBeenCalledTimes(1)
+      expect(mockStartRequest).not.toHaveBeenCalled()
     })
-    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('resets and returns home when back is pressed', async () => {

--- a/src/pages/presentation/tests/PresentationRequestPage.test.tsx
+++ b/src/pages/presentation/tests/PresentationRequestPage.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { PresentationRequestPage } from '../PresentationRequestPage'
+import { routes } from '../../../constants/routes'
+import type { PresentationSessionState } from '../../../hooks/presentation/usePresentationSession'
+
+const mockNavigate = vi.fn()
+const mockStartRequest = vi.fn()
+const mockReset = vi.fn()
+
+let mockSessionState: PresentationSessionState = { status: 'idle' }
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+vi.mock('../../../hooks/presentation/usePresentationSession', () => ({
+  usePresentationSession: () => ({
+    sessionState: mockSessionState,
+    startRequest: mockStartRequest,
+    reset: mockReset,
+  }),
+}))
+
+vi.mock('../../../components/presentation/PresentationPageShell', () => ({
+  PresentationPageShell: ({
+    title,
+    onBack,
+    children,
+  }: {
+    title: string
+    onBack: () => void
+    children: React.ReactNode
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      <button type="button" onClick={onBack}>
+        Back
+      </button>
+      {children}
+    </div>
+  ),
+}))
+
+const validSearch =
+  '?client_id=https%3A%2F%2Fverifier.example' +
+  '&request_uri=https%3A%2F%2Fverifier.example%2Frequest' +
+  '&response_type=vp_token' +
+  '&nonce=nonce-123' +
+  '&scope=openid'
+
+function renderPage(search = validSearch) {
+  return render(
+    <MemoryRouter initialEntries={[`${routes.present}${search}`]}>
+      <Routes>
+        <Route path={routes.present} element={<PresentationRequestPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('PresentationRequestPage', () => {
+  afterEach(() => cleanup())
+
+  beforeEach(() => {
+    mockNavigate.mockReset()
+    mockStartRequest.mockReset()
+    mockReset.mockReset()
+    mockSessionState = { status: 'idle' }
+  })
+
+  it('shows validation error when query params are missing', () => {
+    renderPage('')
+    expect(screen.getByText(/Missing required parameter: client_id/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Scan QR code' })).toBeTruthy()
+    expect(mockStartRequest).not.toHaveBeenCalled()
+  })
+
+  it('starts the presentation session for valid query params', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(mockStartRequest).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows loading state while the session is starting', () => {
+    mockSessionState = { status: 'loading' }
+    renderPage()
+    expect(screen.getByText('Processing proof request…')).toBeTruthy()
+  })
+
+  it('shows API error with retry action', async () => {
+    mockSessionState = {
+      status: 'error',
+      error: {
+        httpStatus: 404,
+        code: 'invalid_presentation_request',
+        message: 'POST /presentation/start failed with 404',
+      },
+    }
+    renderPage()
+
+    expect(
+      screen.getByText(
+        'This presentation request is invalid or has expired. Please ask the verifier for a new QR code.'
+      )
+    ).toBeTruthy()
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(mockReset).toHaveBeenCalled()
+    expect(mockStartRequest).toHaveBeenCalled()
+  })
+
+  it('does not navigate away on success', async () => {
+    mockSessionState = { status: 'success' }
+    renderPage()
+
+    await waitFor(() => {
+      expect(mockStartRequest).toHaveBeenCalledTimes(1)
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('resets and returns home when back is pressed', async () => {
+    renderPage()
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    expect(mockReset).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith(routes.home)
+  })
+})

--- a/src/state/presentation.state.tsx
+++ b/src/state/presentation.state.tsx
@@ -60,8 +60,24 @@ function isVerifierMetadata(value: unknown): value is VerifierMetadata {
   return isRecord(value) && typeof value.client_id === 'string'
 }
 
+function isDcqlQuery(value: unknown): value is ParsedPresentationRequest['dcql_query'] {
+  return (
+    isRecord(value) && Array.isArray(value.credentials) && value.credentials.length > 0
+  )
+}
+
 function isParsedPresentationRequest(value: unknown): value is ParsedPresentationRequest {
-  return isRecord(value)
+  if (!isRecord(value)) return false
+  const hasScope = typeof value.scope === 'string'
+  const hasDcql = isDcqlQuery(value.dcql_query)
+  return (
+    typeof value.client_id === 'string' &&
+    typeof value.nonce === 'string' &&
+    typeof value.response_type === 'string' &&
+    typeof value.response_mode === 'string' &&
+    (hasScope || hasDcql) &&
+    !(hasScope && hasDcql)
+  )
 }
 
 function isMatchingCredential(value: unknown): value is MatchingCredential {

--- a/src/state/tests/presentation.state.test.tsx
+++ b/src/state/tests/presentation.state.test.tsx
@@ -66,7 +66,13 @@ function SetterProbe() {
       <button
         type="button"
         onClick={() =>
-          state.setRequest({ client_id: 'verifier-client', response_type: 'vp_token' })
+          state.setRequest({
+            client_id: 'verifier-client',
+            nonce: 'nonce-123',
+            response_type: 'vp_token',
+            response_mode: 'direct_post',
+            scope: 'openid',
+          })
         }
       >
         set-request
@@ -111,7 +117,13 @@ function SetterProbe() {
             { credentialId: 'cred-1', queryId: 'query-1', format: 'dc+sd-jwt' },
           ])
           state.setDisclosedClaims({ 'cred-1': ['given_name'] })
-          state.setRequest({ client_id: 'new-request', response_type: 'vp_token' })
+          state.setRequest({
+            client_id: 'new-request',
+            nonce: 'nonce-456',
+            response_type: 'vp_token',
+            response_mode: 'direct_post',
+            scope: 'openid',
+          })
         }}
       >
         new-request

--- a/src/types/presentation.ts
+++ b/src/types/presentation.ts
@@ -126,6 +126,7 @@ export type PresentationError = {
 export type PresentationAuthorizationRequest = {
   client_id: string
   request_uri?: string
+  request_uri_method?: 'GET' | 'POST'
   request?: string
   response_type?: string
   nonce?: string

--- a/src/types/presentation.ts
+++ b/src/types/presentation.ts
@@ -55,17 +55,18 @@ export type DcqlQuery = {
 }
 
 /**
- * Normalized presentation authorization request after parsing
- * (authorization request or signed request object).
+ * Normalized authorization request from POST /presentation/start.
+ * Populated by the backend after resolving the scanned QR (including JAR fetch).
+ * Validated by `validateParsedPresentationRequest` before use in the UI.
  */
 export type ParsedPresentationRequest = {
-  response_type?: string
-  response_mode?: string
-  client_id?: string
-  scope?: string
+  client_id: string
+  nonce: string
+  response_type: string
+  response_mode: string
   dcql_query?: DcqlQuery
+  scope?: string
   state?: string
-  nonce?: string
   request_uri?: string
   request_uri_method?: string
   presentation_definition?: Record<string, unknown>
@@ -115,6 +116,35 @@ export type PresentationError = {
   code: PresentationErrorCode
   message: string
   error_description?: string | null
+}
+
+/**
+ * Raw parameters from a scanned presentation QR, sent to POST /presentation/start.
+ * JAR QRs may only include `client_id` and `request_uri`; remaining fields are
+ * resolved server-side into {@link ParsedPresentationRequest}.
+ */
+export type PresentationAuthorizationRequest = {
+  client_id: string
+  request_uri?: string
+  request?: string
+  response_type?: string
+  nonce?: string
+  state?: string
+  response_mode?: string
+  scope?: string
+  dcql_query?: string
+  client_metadata?: string
+  client_metadata_uri?: string
+}
+
+/** Body for POST /presentation/start. */
+export type StartPresentationRequest = PresentationAuthorizationRequest
+
+/** Response from POST /presentation/start (normalized by the wallet backend). */
+export type StartPresentationResponse = {
+  request: ParsedPresentationRequest
+  verifier: VerifierMetadata
+  matching_credentials: MatchingCredential[]
 }
 
 /** Serializable presentation flow data persisted to localStorage. */

--- a/src/utils/presentation/presentationErrors.ts
+++ b/src/utils/presentation/presentationErrors.ts
@@ -1,0 +1,73 @@
+import { ApiError } from '../../api/client'
+import { ContractError } from '../../api/validation'
+import { PresentationError } from '../../api/presentation/start'
+import type { PresentationError as PresentationErrorShape } from '../../types/presentation'
+
+export function toPresentationError(error: unknown): PresentationErrorShape {
+  if (error instanceof PresentationError) {
+    return {
+      httpStatus: error.httpStatus,
+      code: error.code,
+      message: error.message,
+      error_description: error.error_description,
+    }
+  }
+
+  if (error instanceof ContractError) {
+    return {
+      httpStatus: 502,
+      code: 'internal_error',
+      message: 'The server returned an unexpected response. Please try again.',
+      error_description: error.message,
+    }
+  }
+
+  if (error instanceof ApiError) {
+    return {
+      httpStatus: error.status,
+      code: error.errorCode ?? 'internal_error',
+      message: error.message,
+      error_description: error.errorDescription,
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      httpStatus: 0,
+      code: 'internal_error',
+      message: error.message,
+      error_description: null,
+    }
+  }
+
+  return {
+    httpStatus: 0,
+    code: 'internal_error',
+    message: 'An unexpected error occurred while processing the presentation request.',
+    error_description: null,
+  }
+}
+
+export function presentationUserMessage(error: PresentationErrorShape): string {
+  if (error.error_description?.trim()) {
+    return error.error_description.trim()
+  }
+
+  switch (error.code) {
+    case 'invalid_request':
+      return error.message
+    case 'invalid_presentation_request':
+      return 'This presentation request is invalid or has expired. Please ask the verifier for a new QR code.'
+    case 'verifier_metadata_fetch_failed':
+      return "We couldn't load information about the verifier. Please try again."
+    case 'no_matching_credentials':
+      return "You don't have a credential that satisfies this proof request."
+    case 'unauthorized':
+      return 'Your wallet session has expired. Please register again and retry.'
+    case 'internal_error':
+    default:
+      return (
+        error.message || 'Something went wrong while processing the presentation request.'
+      )
+  }
+}

--- a/src/utils/presentation/presentationRequest.ts
+++ b/src/utils/presentation/presentationRequest.ts
@@ -10,6 +10,8 @@ const SUPPORTED_RESPONSE_MODES = new Set([
   'fragment',
   'query',
 ])
+const MAX_REQUEST_URI_LENGTH = 4096
+const MAX_CLIENT_ID_LENGTH = 2048
 
 export type ParsedPresentationRequestParams =
   | { ok: true; authorization: PresentationAuthorizationRequest }
@@ -35,12 +37,44 @@ function pickOptionalParam(
   return value || undefined
 }
 
+/** `request_uri` and `client_metadata_uri` must be HTTPS per OID4VP security requirements. */
 function isHttpsUrl(value: string): boolean {
   try {
     return new URL(value).protocol === 'https:'
   } catch {
     return false
   }
+}
+
+function isJwtStructure(value: string): boolean {
+  const parts = value.split('.')
+  return parts.length === 3 && parts.every((part) => part.length > 0)
+}
+
+function isRequestUriMethod(
+  value: string
+): value is NonNullable<PresentationAuthorizationRequest['request_uri_method']> {
+  return value === 'GET' || value === 'POST'
+}
+
+function isValidClientId(value: string): boolean {
+  if (value.length > MAX_CLIENT_ID_LENGTH) {
+    return false
+  }
+  if (value.startsWith('https://')) {
+    try {
+      new URL(value)
+      return true
+    } catch {
+      return false
+    }
+  }
+  const knownPrefixes = ['did:', 'x509_san_dns:', 'x509_hash:', 'urn:']
+  if (knownPrefixes.some((prefix) => value.startsWith(prefix))) {
+    return true
+  }
+  // Opaque client_id values are permitted; backend performs authoritative validation.
+  return value.length > 0 && !/\s/.test(value)
 }
 
 /**
@@ -55,6 +89,9 @@ export function parsePresentationRequestParams(
   if (!client_id) {
     return invalidRequest('Missing required parameter: client_id.')
   }
+  if (!isValidClientId(client_id)) {
+    return invalidRequest('Invalid client_id format.')
+  }
 
   const request_uri = pickOptionalParam(searchParams, 'request_uri')
   const request = pickOptionalParam(searchParams, 'request')
@@ -65,8 +102,31 @@ export function parsePresentationRequestParams(
     return invalidRequest('Provide either request_uri or request, not both.')
   }
 
-  if (request_uri && !isHttpsUrl(request_uri)) {
-    return invalidRequest('Invalid request_uri format. Expected an https URL.')
+  if (request_uri) {
+    if (request_uri.length > MAX_REQUEST_URI_LENGTH) {
+      return invalidRequest('request_uri exceeds maximum allowed length.')
+    }
+    if (!isHttpsUrl(request_uri)) {
+      return invalidRequest('Invalid request_uri format. Expected an https URL.')
+    }
+  }
+
+  if (request && !isJwtStructure(request)) {
+    return invalidRequest(
+      'Invalid request format. Expected a JWT (header.payload.signature).'
+    )
+  }
+
+  const requestUriMethodRaw = pickOptionalParam(searchParams, 'request_uri_method')
+  let request_uri_method: PresentationAuthorizationRequest['request_uri_method']
+  if (requestUriMethodRaw) {
+    if (!isRequestUriMethod(requestUriMethodRaw)) {
+      return invalidRequest('Unsupported request_uri_method. Expected GET or POST.')
+    }
+    request_uri_method = requestUriMethodRaw
+  }
+  if (request_uri_method && !request_uri) {
+    return invalidRequest('request_uri_method is only valid with request_uri.')
   }
 
   const response_type = searchParams.get('response_type')?.trim()
@@ -74,7 +134,10 @@ export function parsePresentationRequestParams(
   const scope = pickOptionalParam(searchParams, 'scope')
   const dcql_query = pickOptionalParam(searchParams, 'dcql_query')
 
-  // JAR flows: request_uri / signed request may carry the remaining parameters.
+  // JAR flows (`request_uri` or signed `request`): response_type, nonce, and
+  // scope/dcql_query may live inside the fetched or embedded JWT. We do not
+  // decode the JWT client-side; POST /presentation/start resolves and validates
+  // the full authorization request server-side.
   const isJarFlow = Boolean(request_uri || request)
 
   if (!isJarFlow) {
@@ -115,6 +178,7 @@ export function parsePresentationRequestParams(
 
   if (request_uri) authorization.request_uri = request_uri
   if (request) authorization.request = request
+  if (request_uri_method) authorization.request_uri_method = request_uri_method
   if (response_type) authorization.response_type = response_type
   if (nonce) authorization.nonce = nonce
 

--- a/src/utils/presentation/presentationRequest.ts
+++ b/src/utils/presentation/presentationRequest.ts
@@ -1,0 +1,144 @@
+import type {
+  PresentationAuthorizationRequest,
+  PresentationError,
+} from '../../types/presentation'
+
+const SUPPORTED_RESPONSE_TYPES = new Set(['vp_token', 'vp_token id_token'])
+const SUPPORTED_RESPONSE_MODES = new Set([
+  'direct_post',
+  'direct_post.jwt',
+  'fragment',
+  'query',
+])
+
+export type ParsedPresentationRequestParams =
+  | { ok: true; authorization: PresentationAuthorizationRequest }
+  | { ok: false; error: PresentationError }
+
+function invalidRequest(message: string): ParsedPresentationRequestParams {
+  return {
+    ok: false,
+    error: {
+      httpStatus: 400,
+      code: 'invalid_request',
+      message,
+      error_description: null,
+    },
+  }
+}
+
+function pickOptionalParam(
+  searchParams: URLSearchParams,
+  key: string
+): string | undefined {
+  const value = searchParams.get(key)?.trim()
+  return value || undefined
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parse and validate OpenID4VP authorization request query parameters.
+ * @see https://github.com/ADORSYS-GIS/cloud-wallet-ui/issues/84
+ * @see https://openid.net/specs/openid-4-verifiable-presentations-1_0.html
+ */
+export function parsePresentationRequestParams(
+  searchParams: URLSearchParams
+): ParsedPresentationRequestParams {
+  const client_id = searchParams.get('client_id')?.trim()
+  if (!client_id) {
+    return invalidRequest('Missing required parameter: client_id.')
+  }
+
+  const request_uri = pickOptionalParam(searchParams, 'request_uri')
+  const request = pickOptionalParam(searchParams, 'request')
+  if (!request_uri && !request) {
+    return invalidRequest('One of request_uri or request is required.')
+  }
+  if (request_uri && request) {
+    return invalidRequest('Provide either request_uri or request, not both.')
+  }
+
+  if (request_uri && !isHttpsUrl(request_uri)) {
+    return invalidRequest('Invalid request_uri format. Expected an https URL.')
+  }
+
+  const response_type = searchParams.get('response_type')?.trim()
+  const nonce = searchParams.get('nonce')?.trim()
+  const scope = pickOptionalParam(searchParams, 'scope')
+  const dcql_query = pickOptionalParam(searchParams, 'dcql_query')
+
+  // JAR flows: request_uri / signed request may carry the remaining parameters.
+  const isJarFlow = Boolean(request_uri || request)
+
+  if (!isJarFlow) {
+    if (!response_type) {
+      return invalidRequest('Missing required parameter: response_type.')
+    }
+    if (!nonce) {
+      return invalidRequest('Missing required parameter: nonce.')
+    }
+    if (!scope && !dcql_query) {
+      return invalidRequest('One of scope or dcql_query is required.')
+    }
+  }
+
+  if (response_type && !SUPPORTED_RESPONSE_TYPES.has(response_type)) {
+    return invalidRequest(
+      'Unsupported response_type. Expected vp_token or vp_token id_token.'
+    )
+  }
+
+  if (scope && dcql_query) {
+    return invalidRequest('Provide either scope or dcql_query, not both.')
+  }
+
+  const state = pickOptionalParam(searchParams, 'state')
+
+  const response_mode = pickOptionalParam(searchParams, 'response_mode')
+  if (response_mode && !SUPPORTED_RESPONSE_MODES.has(response_mode)) {
+    return invalidRequest(`Unsupported response_mode: ${response_mode}.`)
+  }
+
+  const client_metadata_uri = pickOptionalParam(searchParams, 'client_metadata_uri')
+  if (client_metadata_uri && !isHttpsUrl(client_metadata_uri)) {
+    return invalidRequest('Invalid client_metadata_uri format. Expected an https URL.')
+  }
+
+  const authorization: PresentationAuthorizationRequest = { client_id }
+
+  if (request_uri) authorization.request_uri = request_uri
+  if (request) authorization.request = request
+  if (response_type) authorization.response_type = response_type
+  if (nonce) authorization.nonce = nonce
+
+  if (state) authorization.state = state
+  if (response_mode) authorization.response_mode = response_mode
+  if (scope) authorization.scope = scope
+  if (dcql_query) authorization.dcql_query = dcql_query
+
+  const client_metadata = pickOptionalParam(searchParams, 'client_metadata')
+  if (client_metadata) authorization.client_metadata = client_metadata
+  if (client_metadata_uri) authorization.client_metadata_uri = client_metadata_uri
+
+  return { ok: true, authorization }
+}
+
+/** Build an internal `/present` route from authorization params (used after QR scan). */
+export function presentationRequestPath(
+  authorization: PresentationAuthorizationRequest
+): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(authorization)) {
+    if (value !== undefined) {
+      params.set(key, value)
+    }
+  }
+  return `/present?${params.toString()}`
+}

--- a/src/utils/presentation/presentationScanInput.ts
+++ b/src/utils/presentation/presentationScanInput.ts
@@ -1,0 +1,37 @@
+import {
+  parsePresentationRequestParams,
+  presentationRequestPath,
+} from './presentationRequest'
+
+const PRESENTATION_URL_PROTOCOLS = new Set(['https:', 'openid4vp:'])
+
+/**
+ * Parse a scanned OpenID4VP QR code into an internal `/present` route.
+ * Returns null when the input is not a recognizable authorization request.
+ */
+export function parsePresentationScanInput(input: string): string | null {
+  const value = input.trim()
+  if (!value) {
+    return null
+  }
+
+  const fromSearchParams = (searchParams: URLSearchParams): string | null => {
+    const result = parsePresentationRequestParams(searchParams)
+    return result.ok ? presentationRequestPath(result.authorization) : null
+  }
+
+  try {
+    const url = new URL(value)
+    if (PRESENTATION_URL_PROTOCOLS.has(url.protocol)) {
+      return fromSearchParams(url.searchParams)
+    }
+  } catch {
+    // Fall through to raw query-string parsing.
+  }
+
+  if (value.includes('=')) {
+    return fromSearchParams(new URLSearchParams(value))
+  }
+
+  return null
+}

--- a/src/utils/presentation/presentationScanInput.ts
+++ b/src/utils/presentation/presentationScanInput.ts
@@ -3,35 +3,17 @@ import {
   presentationRequestPath,
 } from './presentationRequest'
 
-const PRESENTATION_URL_PROTOCOLS = new Set(['https:', 'openid4vp:'])
-
 /**
- * Parse a scanned OpenID4VP QR code into an internal `/present` route.
- * Returns null when the input is not a recognizable authorization request.
+ * Parse a scanned OpenID4VP QR code (query-string payload) into an internal
+ * `/present` route. Returns null when the input is not a recognizable
+ * authorization request.
  */
 export function parsePresentationScanInput(input: string): string | null {
   const value = input.trim()
-  if (!value) {
+  if (!value.includes('=')) {
     return null
   }
 
-  const fromSearchParams = (searchParams: URLSearchParams): string | null => {
-    const result = parsePresentationRequestParams(searchParams)
-    return result.ok ? presentationRequestPath(result.authorization) : null
-  }
-
-  try {
-    const url = new URL(value)
-    if (PRESENTATION_URL_PROTOCOLS.has(url.protocol)) {
-      return fromSearchParams(url.searchParams)
-    }
-  } catch {
-    // Fall through to raw query-string parsing.
-  }
-
-  if (value.includes('=')) {
-    return fromSearchParams(new URLSearchParams(value))
-  }
-
-  return null
+  const result = parsePresentationRequestParams(new URLSearchParams(value))
+  return result.ok ? presentationRequestPath(result.authorization) : null
 }

--- a/src/utils/presentation/tests/presentationRequest.test.ts
+++ b/src/utils/presentation/tests/presentationRequest.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parsePresentationRequestParams,
+  presentationRequestPath,
+} from '../presentationRequest'
+
+const validParams = new URLSearchParams({
+  client_id: 'https://verifier.example',
+  request_uri: 'https://verifier.example/request',
+  response_type: 'vp_token',
+  nonce: 'nonce-123',
+  scope: 'openid',
+})
+
+describe('parsePresentationRequestParams', () => {
+  it('accepts a valid request_uri flow', () => {
+    const result = parsePresentationRequestParams(validParams)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.authorization.client_id).toBe('https://verifier.example')
+      expect(result.authorization.request_uri).toBe('https://verifier.example/request')
+      expect(result.authorization.scope).toBe('openid')
+    }
+  })
+
+  it('accepts a direct JWT request parameter', () => {
+    const params = new URLSearchParams({
+      client_id: 'verifier-client',
+      request: 'eyJhbGciOiJFUzI1NiJ9.mock',
+      response_type: 'vp_token id_token',
+      nonce: 'nonce-abc',
+      dcql_query: '{"credentials":[]}',
+    })
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts a minimal JAR request_uri (params resolved by backend)', () => {
+    const params = new URLSearchParams({
+      client_id: 'x509_san_dns:verifier.example',
+      request_uri: 'https://verifier.example/oid4vp-auth/request.jwt/q845ZZKf',
+    })
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.authorization.response_type).toBeUndefined()
+      expect(result.authorization.nonce).toBeUndefined()
+    }
+  })
+
+  it('rejects missing client_id', () => {
+    const params = new URLSearchParams(validParams)
+    params.delete('client_id')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('invalid_request')
+    }
+  })
+
+  it('rejects invalid request_uri format', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('request_uri', 'not-a-valid-uri')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toContain('request_uri')
+    }
+  })
+
+  it('rejects http request_uri', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('request_uri', 'http://verifier.example/request')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects unsupported response_mode', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('response_mode', 'unsupported_mode')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects invalid client_metadata_uri format', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('client_metadata_uri', 'ftp://bad.example/meta')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+  })
+
+  it('builds an internal /present route from authorization params', () => {
+    expect(
+      presentationRequestPath({
+        client_id: 'verifier',
+        request_uri: 'https://verifier.example/request',
+        response_type: 'vp_token',
+        nonce: 'n1',
+        scope: 'openid',
+      })
+    ).toContain('/present?')
+  })
+})

--- a/src/utils/presentation/tests/presentationRequest.test.ts
+++ b/src/utils/presentation/tests/presentationRequest.test.ts
@@ -4,6 +4,8 @@ import {
   presentationRequestPath,
 } from '../presentationRequest'
 
+const validJwt = 'eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.mock-signature'
+
 const validParams = new URLSearchParams({
   client_id: 'https://verifier.example',
   request_uri: 'https://verifier.example/request',
@@ -23,10 +25,20 @@ describe('parsePresentationRequestParams', () => {
     }
   })
 
+  it('accepts request_uri_method when provided with request_uri', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('request_uri_method', 'POST')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.authorization.request_uri_method).toBe('POST')
+    }
+  })
+
   it('accepts a direct JWT request parameter', () => {
     const params = new URLSearchParams({
       client_id: 'verifier-client',
-      request: 'eyJhbGciOiJFUzI1NiJ9.mock',
+      request: validJwt,
       response_type: 'vp_token id_token',
       nonce: 'nonce-abc',
       dcql_query: '{"credentials":[]}',
@@ -58,6 +70,16 @@ describe('parsePresentationRequestParams', () => {
     }
   })
 
+  it('rejects invalid client_id format', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('client_id', 'https://not a valid url')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toContain('client_id')
+    }
+  })
+
   it('rejects invalid request_uri format', () => {
     const params = new URLSearchParams(validParams)
     params.set('request_uri', 'not-a-valid-uri')
@@ -71,6 +93,48 @@ describe('parsePresentationRequestParams', () => {
   it('rejects http request_uri', () => {
     const params = new URLSearchParams(validParams)
     params.set('request_uri', 'http://verifier.example/request')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects request_uri that exceeds maximum length', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('request_uri', `https://verifier.example/${'a'.repeat(4096)}`)
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toContain('request_uri')
+    }
+  })
+
+  it('rejects malformed JWT request parameter', () => {
+    const params = new URLSearchParams({
+      client_id: 'verifier-client',
+      request: 'not-a-jwt',
+    })
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toContain('JWT')
+    }
+  })
+
+  it('rejects unsupported request_uri_method', () => {
+    const params = new URLSearchParams(validParams)
+    params.set('request_uri_method', 'PUT')
+    const result = parsePresentationRequestParams(params)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toContain('request_uri_method')
+    }
+  })
+
+  it('rejects request_uri_method without request_uri', () => {
+    const params = new URLSearchParams({
+      client_id: 'verifier-client',
+      request: validJwt,
+      request_uri_method: 'GET',
+    })
     const result = parsePresentationRequestParams(params)
     expect(result.ok).toBe(false)
   })
@@ -94,6 +158,7 @@ describe('parsePresentationRequestParams', () => {
       presentationRequestPath({
         client_id: 'verifier',
         request_uri: 'https://verifier.example/request',
+        request_uri_method: 'POST',
         response_type: 'vp_token',
         nonce: 'n1',
         scope: 'openid',

--- a/src/utils/presentation/tests/presentationScanInput.test.ts
+++ b/src/utils/presentation/tests/presentationScanInput.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { parsePresentationScanInput } from '../presentationScanInput'
+
+const baseQuery =
+  'client_id=https%3A%2F%2Fverifier.example' +
+  '&request_uri=https%3A%2F%2Fverifier.example%2Frequest' +
+  '&response_type=vp_token' +
+  '&nonce=nonce-123' +
+  '&scope=openid'
+
+describe('parsePresentationScanInput', () => {
+  it('parses an https presentation QR into an internal /present route', () => {
+    const result = parsePresentationScanInput(
+      `https://wallet.example/present?${baseQuery}`
+    )
+    expect(result).toBe(`/present?${baseQuery}`)
+  })
+
+  it('parses an openid4vp:// scheme link', () => {
+    const result = parsePresentationScanInput(`openid4vp://?${baseQuery}`)
+    expect(result).toBe(`/present?${baseQuery}`)
+  })
+
+  it('parses a raw query string from a QR code', () => {
+    const result = parsePresentationScanInput(baseQuery)
+    expect(result).toBe(`/present?${baseQuery}`)
+  })
+
+  it('returns null for unrecognized input', () => {
+    expect(parsePresentationScanInput('not-a-presentation-qr')).toBeNull()
+    expect(parsePresentationScanInput('client_id=only-client')).toBeNull()
+  })
+})

--- a/src/utils/presentation/tests/presentationScanInput.test.ts
+++ b/src/utils/presentation/tests/presentationScanInput.test.ts
@@ -9,21 +9,16 @@ const baseQuery =
   '&scope=openid'
 
 describe('parsePresentationScanInput', () => {
-  it('parses an https presentation QR into an internal /present route', () => {
-    const result = parsePresentationScanInput(
-      `https://wallet.example/present?${baseQuery}`
-    )
-    expect(result).toBe(`/present?${baseQuery}`)
-  })
-
-  it('parses an openid4vp:// scheme link', () => {
-    const result = parsePresentationScanInput(`openid4vp://?${baseQuery}`)
-    expect(result).toBe(`/present?${baseQuery}`)
-  })
-
   it('parses a raw query string from a QR code', () => {
     const result = parsePresentationScanInput(baseQuery)
     expect(result).toBe(`/present?${baseQuery}`)
+  })
+
+  it('returns null for deep-link style URIs', () => {
+    expect(parsePresentationScanInput(`openid4vp://?${baseQuery}`)).toBeNull()
+    expect(
+      parsePresentationScanInput(`https://wallet.example/present?${baseQuery}`)
+    ).toBeNull()
   })
 
   it('returns null for unrecognized input', () => {


### PR DESCRIPTION
Create a page that handles incoming presentation requests from a verifier. The page serves as the entry point when a verifier redirects the user to the wallet when a QR code is scanned.

The page must parse the OpenID4VP request URI, validate required parameters, initialize the presentation flow, and route to the appropriate next screen.

### Tasks
- [ ] Create `/present` route and `PresentationRequestPage` component
- [ ] Parse OpenID4VP request URI from URL query parameters (`request_uri`, `request`, `client_id`, etc.)
- [ ] Support both `request_uri` (fetch) and direct `request` (JWT) parameters
- [ ] Validate required request parameters per OpenID4VP spec
- [ ] Call backend endpoint `POST /presentation/start` to validate and parse request
- [ ] Handle invalid or malformed requests with user-friendly error messages
- [ ] Store parsed request data in `PresentationProvider` state
- [ ] Display loading state while request is being processed
- [ ] Display error screen when the request cannot be processed

### Request Parameters to Support
- `client_id` (required)
- `request_uri` / `request` (one required)
- `response_type` (must be `vp_token` or `vp_token id_token`)
- `nonce` (required)
- `state` (optional)
- `response_mode` (direct_post, direct_post.jwt, fragment, query)
- `dcql_query` or `scope` (one required)
- `client_metadata` / `client_metadata_uri` (optional)

### Error Scenarios
- Missing required parameters
- Invalid request URI format
- Backend validation failure (expired request, invalid signature)
- Network failure fetching request_uri
- Unsupported response_mode

### Acceptance Criteria
- User can open a presentation request URL via QR Code
- Valid requests initialize the presentation flow and route to details screen
- Invalid requests show an error message with clear explanation
- Request information is available to subsequent screens via state
- No application crash occurs for malformed requests
- Loading indicator shown during request processing

Closes #84 